### PR TITLE
Ensure line item extraction always returns list

### DIFF
--- a/agents/data_extraction_agent.py
+++ b/agents/data_extraction_agent.py
@@ -135,9 +135,13 @@ class DataExtractionAgent(BaseAgent):
         logger.info("  -> Stage 2b: Extracting Line Items...")
         prompt = "Extract line items (description, quantity, unitPrice, lineTotal) from the text. Respond with a JSON object with a single \"lineItems\" key."
         try:
-            response = ollama.generate(model=self.extraction_model,
-                                       prompt=f"{prompt}\n\nDocument Content:\n---\n{text}\n---\nJSON:", format='json')
-            return json.loads(response.get('response', '{"lineItems": []}')).get('lineItems')
+            response = ollama.generate(
+                model=self.extraction_model,
+                prompt=f"{prompt}\n\nDocument Content:\n---\n{text}\n---\nJSON:",
+                format='json'
+            )
+            # Ensure we always return a list; missing keys should yield an empty list rather than ``None``
+            return json.loads(response.get('response', '{"lineItems": []}')).get('lineItems', [])
         except Exception as e:
             logger.error(f"Line item extraction failed: {e}");
             return []


### PR DESCRIPTION
## Summary
- Avoid returning `None` from the data extraction agent when the LLM omits `lineItems`.
- Guarantee `_extract_line_items` provides an empty list on missing key to prevent downstream failures.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68944f40b05083329d787b2b79f03c4c