### PR TITLE
Implement PDF data extraction and supplier ranking pipeline

### DIFF
--- a/api/routers/workflows.py
+++ b/api/routers/workflows.py
@@ -1,15 +1,58 @@
 # ProcWise/api/routers/workflows.py
+"""API routes exposing the agent workflows."""
+from __future__ import annotations
 
 import json
 import os
+from typing import List, Optional
 
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel
 
 from orchestration.orchestrator import Orchestrator
 from services.model_selector import RAGPipeline
 
+
+# ---------------------------------------------------------------------------
+# Dependency helpers
+# ---------------------------------------------------------------------------
+def get_orchestrator(request: Request) -> Orchestrator:
+    orchestrator = getattr(request.app.state, "orchestrator", None)
+    if not orchestrator:
+        raise HTTPException(status_code=503, detail="Orchestrator service is not available.")
+    return orchestrator
+
+
+def get_rag_pipeline(request: Request) -> RAGPipeline:
+    pipeline = getattr(request.app.state, "rag_pipeline", None)
+    if not pipeline:
+        raise HTTPException(status_code=503, detail="RAG Pipeline service is not available.")
+    return pipeline
+
+
+class QuestionParams:
+    """Utility class used with ``Depends`` to parse multipart form requests."""
+
+    def __init__(
+        self,
+        query: str = Form(...),
+        user_id: str = Form(...),
+        model_name: Optional[str] = Form(None),
+        doc_type: Optional[str] = Form(None),
+        product_type: Optional[str] = Form(None),
+        files: List[UploadFile] | None = File(None),
+    ):
+        self.query = query
+        self.user_id = user_id
+        self.model_name = model_name
+        self.doc_type = doc_type
+        self.product_type = product_type
+        self.files = files or []
+
+
 class RankingRequest(BaseModel):
     query: str
+
 
 class ExtractRequest(BaseModel):
     s3_prefix: Optional[str] = None
@@ -23,33 +66,45 @@ class AgentType(BaseModel):
     dependencies: List[str]
 
 
-def load_from_json(file_path: str):
-    try:
-        with open(file_path, "r") as f:
-            return json.load(f)
-    except FileNotFoundError:
-        raise HTTPException(
-            status_code=500, detail=f"Configuration file not found: {file_path}"
-        )
-    except json.JSONDecodeError:
-        raise HTTPException(
-            status_code=500, detail=f"Error decoding JSON from file: {file_path}"
-        )
-
-
 router = APIRouter(prefix="/workflows", tags=["Agent Workflows"])
 
 
-
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
 @router.post("/ask")
 async def ask_question(
     params: QuestionParams = Depends(),
     pipeline: RAGPipeline = Depends(get_rag_pipeline),
 ):
     if len(params.files) > 3:
-        raise HTTPException(400, "Max 3 files allowed.")
+        raise HTTPException(status_code=400, detail="Max 3 files allowed.")
     file_data = [(await f.read(), f.filename) for f in params.files if f.filename]
+    result = pipeline.answer_question(
+        query=params.query,
+        user_id=params.user_id,
+        model_name=params.model_name,
+        files=file_data,
+        doc_type=params.doc_type,
+        product_type=params.product_type,
+    )
+    return result
 
+
+@router.post("/rank")
+def rank_suppliers(
+    req: RankingRequest,
+    orchestrator: Orchestrator = Depends(get_orchestrator),
+):
+    return orchestrator.execute_ranking_flow(req.query)
+
+
+@router.post("/extract")
+def extract_documents(
+    req: ExtractRequest,
+    orchestrator: Orchestrator = Depends(get_orchestrator),
+):
+    return orchestrator.execute_extraction_flow(req.s3_prefix, req.s3_object_key)
 
 
 @router.get(
@@ -58,8 +113,8 @@ async def ask_question(
     summary="Get agent types and their resource dependencies",
 )
 def get_agent_types():
-    """
-    Returns a list of all defined agent types, their descriptions,
-    and their dependencies from the agent_definitions.json file.
-    """
-
+    """Return the agent catalogue defined in ``agent_definitions.json``."""
+    file_path = os.path.join(os.path.dirname(__file__), "..", "..", "agent_definitions.json")
+    with open(file_path, "r") as f:
+        data = json.load(f)
+    return [AgentType(**agent) for agent in data]

--- a/engines/query_engine.py
+++ b/engines/query_engine.py
@@ -1,10 +1,52 @@
 # ProcWise/engines/query_engine.py
+"""Light‑weight database access layer used by the orchestrator.
+
+Only a single method is required for the exercises in this repository –
+``fetch_supplier_data`` which collects information about suppliers by
+combining the supplier master data with aggregated information from invoice
+and purchase order tables.  The returned ``pandas.DataFrame`` is consumed by
+:class:`SupplierRankingAgent`.
+"""
+from __future__ import annotations
 
 import pandas as pd
-
+from .base_engine import BaseEngine
 
 
 class QueryEngine(BaseEngine):
     def __init__(self, agent_nick):
+        super().__init__()
         self.agent_nick = agent_nick
 
+    def fetch_supplier_data(self, intent: dict) -> pd.DataFrame:
+        """Return supplier information required for ranking.
+
+        The query joins ``proc.supplier`` with invoice and purchase order
+        tables.  Only suppliers that appear in either table are returned.  Raw
+        numeric metrics are suffixed with ``_score_raw`` so that the ranking
+        agent can normalise them according to the defined policies.
+        """
+        sql = """
+            SELECT s.supplier_id,
+                   s.supplier_name,
+                   s.payment_terms     AS payment_terms_raw,
+                   s.price_score       AS price_score_raw,
+                   s.delivery_score    AS delivery_score_raw,
+                   s.risk_score        AS risk_score_raw,
+                   COALESCE(inv.total_invoiced, 0) AS total_invoiced_score_raw,
+                   COALESCE(po.total_ordered, 0)  AS total_ordered_score_raw
+            FROM proc.supplier s
+            LEFT JOIN (
+                SELECT supplier_id, SUM(total_amount) AS total_invoiced
+                FROM proc.invoice
+                GROUP BY supplier_id
+            ) inv ON inv.supplier_id = s.supplier_id
+            LEFT JOIN (
+                SELECT supplier_id, SUM(total_amount) AS total_ordered
+                FROM proc.purchase_order
+                GROUP BY supplier_id
+            ) po ON po.supplier_id = s.supplier_id
+            WHERE inv.supplier_id IS NOT NULL OR po.supplier_id IS NOT NULL;
+        """
+        with self.agent_nick.get_db_connection() as conn:
+            return pd.read_sql(sql, conn)


### PR DESCRIPTION
## Summary
- Rewrote data extraction agent to parse PDF invoices/POs/quotes, fallback to supplier name, embed document summaries in Qdrant and persist structured data to Postgres
- Added database query engine joining supplier, invoice and PO tables to feed ranking agent
- Completed workflow API with `/ask`, `/rank`, `/extract` and `/types` endpoints for frontend consumption

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894a1aa8e888332a57170d77c52d05d