### PR TITLE
Add missing agent context and routing helpers

### DIFF
--- a/engines/routing_engine.py
+++ b/engines/routing_engine.py
@@ -1,9 +1,15 @@
 import json
 import logging
-from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+# Fallback routing configuration used if no external model is provided.
+routing_model: Dict[str, Any] = {
+    "global_settings": {"max_chain_depth": 10},
+    "routing_rules": [],
+}
 
 
 @dataclass

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -22,6 +22,7 @@ class Orchestrator:
         self.policy_engine = agent_nick.policy_engine
         self.query_engine = agent_nick.query_engine
         self.routing_engine = agent_nick.routing_engine
+        self.routing_model = self.routing_engine.routing_model
         self.executor = ThreadPoolExecutor(max_workers=self.settings.max_workers)
 
     def execute_workflow(self, workflow_name: str, input_data: Dict,


### PR DESCRIPTION
## Summary
- Define AgentStatus enum plus AgentContext and AgentOutput dataclasses
- Add an Ollama wrapper and routing engine hookup in BaseAgent
- Provide default routing model and cleanup in RoutingEngine
- Ensure Orchestrator uses the loaded routing model

## Testing
- `python -m py_compile agents/base_agent.py engines/routing_engine.py orchestration/orchestrator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894de70309083328d031c622cc43b48