### PR TITLE
Add runtime settings and default routing model

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -30,6 +30,20 @@ class Settings(BaseSettings):
     script_user: str = "AgentNick"
     audit_columns: List[str] = ['created_date', 'created_by', 'last_modified_by', 'last_modified_date']
 
+    # Worker and processing settings
+    max_workers: int = Field(default=4, env="MAX_WORKERS")
+    parallel_processing: bool = Field(default=False, env="PARALLEL_PROCESSING")
+
+    # Learning and optimization
+    enable_learning: bool = Field(default=False, env="ENABLE_LEARNING")
+
+    # Caching settings
+    cache_enabled: bool = Field(default=False, env="CACHE_ENABLED")
+    cache_ttl: int = Field(default=3600, env="CACHE_TTL")
+
+    # Auditing settings
+    audit_enabled: bool = Field(default=True, env="AUDIT_ENABLED")
+
     class Config:
         env_file = ENV_FILE_PATH
         env_file_encoding = 'utf-8'

--- a/models/routing_model.json
+++ b/models/routing_model.json
@@ -1,0 +1,6 @@
+{
+  "global_settings": {
+    "max_chain_depth": 10
+  },
+  "routing_rules": []
+}


### PR DESCRIPTION
## Summary
- extend Settings with worker, caching, learning, and auditing fields
- provide default routing_model.json to avoid load errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ebb8af688332997374aebbeabc43