### PR TITLE
Fix routing model loading path

### DIFF
--- a/engines/routing_engine.py
+++ b/engines/routing_engine.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,10 @@ class RoutingEngine:
     def load_routing_rules(self):
         """Load routing rules from configuration"""
         try:
-            with open('models/routing_model.json', 'r') as f:
+            model_path = (
+                Path(__file__).resolve().parent.parent / "models" / "routing_model.json"
+            )
+            with model_path.open("r") as f:
                 self.routing_model = json.load(f)
         except Exception as e:
             logger.error(f"Failed to load routing model: {e}")


### PR DESCRIPTION
## Summary
- Load routing model using an absolute path so configuration is found regardless of working directory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894efe4b3a483328f747d11d23d4886