### PR TITLE
Fix workflow endpoints and agent interfaces

### DIFF
--- a/engines/query_engine.py
+++ b/engines/query_engine.py
@@ -18,7 +18,7 @@ class QueryEngine(BaseEngine):
         super().__init__()
         self.agent_nick = agent_nick
 
-    def fetch_supplier_data(self, intent: dict) -> pd.DataFrame:
+    def fetch_supplier_data(self, intent: dict | None = None) -> pd.DataFrame:
         """Return supplier information required for ranking.
 
         The query joins ``proc.supplier`` with invoice and purchase order

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -142,7 +142,7 @@ class Orchestrator:
         """Execute supplier ranking workflow"""
         # Get supplier data first
         context.input_data['supplier_data'] = self.query_engine.fetch_supplier_data(
-            context.input_data.get('suppliers', [])
+            context.input_data
         )
 
         # Execute ranking


### PR DESCRIPTION
## Summary
- Tolerate placeholder file paths in /ask and verify files exist before reading
- Refactor DataExtractionAgent and SupplierRankingAgent to use `AgentContext` and return `AgentOutput`
- Pull supplier data from `proc.supplier` via QueryEngine in ranking workflow

## Testing
- `pytest`
- `python -m py_compile agents/data_extraction_agent.py agents/supplier_ranking_agent.py api/routers/workflows.py engines/query_engine.py orchestration/orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_689500eab8448332805f723416b17f1d