### PR TITLE
Ensure supplier ranking workflow uses public API and fix DataExtractionAgent invocation

### DIFF
--- a/agents/data_extraction_agent.py
+++ b/agents/data_extraction_agent.py
@@ -223,12 +223,20 @@ class DataExtractionAgent(BaseAgent):
 
 
 if __name__ == "__main__":
-    # This is just a placeholder to allow running the module directly for testing.
-    # In production, this agent would be invoked by the main application logic.
-    from agents.base_agent import AgentNick
+    # Simple manual invocation used during local development. The production
+    # system always provides an ``AgentContext`` via the orchestrator.
+    from agents.base_agent import AgentNick, AgentContext
 
     agent_nick = AgentNick()
     logging.basicConfig(level=logging.INFO)
     agent = DataExtractionAgent(agent_nick)  # Replace with actual AgentNick instance
-    result = agent.run(s3_prefix="Invoices/")
+
+    context = AgentContext(
+        workflow_id="manual-test",
+        agent_id="data_extraction",
+        user_id=agent_nick.settings.script_user,
+        input_data={"s3_prefix": "Invoices/"},
+    )
+
+    result = agent.run(context)
     print(result)

--- a/api/routers/workflows.py
+++ b/api/routers/workflows.py
@@ -108,7 +108,11 @@ def rank_suppliers(
     req: RankingRequest,
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ):
-    return orchestrator.execute_ranking_flow(req.query)
+    # Use the public workflow entry point so that the orchestrator can build a
+    # proper ``AgentContext``. Calling internal methods directly would bypass
+    # this setup and lead to attribute errors such as ``'str' object has no
+    # attribute 'input_data'`` when the workflow tries to access context fields.
+    return orchestrator.execute_workflow("supplier_ranking", {"query": req.query})
 
 
 @router.post("/extract")


### PR DESCRIPTION
## Summary
- route supplier ranking requests through `execute_workflow` to ensure proper context creation
- fix manual DataExtractionAgent invocation by constructing an AgentContext

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895072c35e48332a6c78ec270420f12