### PR TITLE
Implement policy validation for supplier ranking workflows

### DIFF
--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from engines.policy_engine import PolicyEngine
+
+
+def test_valid_criteria_allowed():
+    engine = PolicyEngine()
+    result = engine.validate_workflow('supplier_ranking', 'user1', {'criteria': ['price', 'delivery']})
+    assert result['allowed'] is True
+
+
+def test_invalid_criteria_blocked():
+    engine = PolicyEngine()
+    result = engine.validate_workflow('supplier_ranking', 'user1', {'criteria': ['unknown']})
+    assert result['allowed'] is False


### PR DESCRIPTION
## Summary
- add `validate_workflow` to PolicyEngine to enforce supplier ranking criteria policies
- ensure orchestrator reads `allowed` flag from validation result
- add tests for valid and invalid supplier ranking criteria

## Testing
- `pytest tests/test_policy_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_6895124bd17c8332aaacc98b71b1cfe0