### PR TITLE
Add process routing logging and improve document embeddings

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -19,6 +19,7 @@ from orchestration.prompt_engine import PromptEngine
 from engines.policy_engine import PolicyEngine
 from engines.query_engine import QueryEngine
 from engines.routing_engine import RoutingEngine
+from services.process_routing_service import ProcessRoutingService
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ class AgentNick:
         self.policy_engine = PolicyEngine()
         self.query_engine = QueryEngine(self)
         self.routing_engine = RoutingEngine(self)
+        self.process_routing_service = ProcessRoutingService(self)
         logger.info("Engines initialized.")
 
         self.agents = {}
@@ -122,7 +124,11 @@ class AgentNick:
             collection_info = self.qdrant_client.get_collection(collection_name=collection_name)
             logger.info(f"Qdrant collection '{collection_name}' already exists.")
             existing_indexes = collection_info.payload_schema.keys()
-            required_indexes = {"document_type": models.PayloadSchemaType.KEYWORD, "product_type": models.PayloadSchemaType.KEYWORD}
+            required_indexes = {
+                "document_type": models.PayloadSchemaType.KEYWORD,
+                "product_type": models.PayloadSchemaType.KEYWORD,
+                "record_id": models.PayloadSchemaType.KEYWORD,
+            }
             for field_name, field_schema in required_indexes.items():
                 if field_name not in existing_indexes:
                     logger.warning(f"Index for '{field_name}' not found. Creating it now...")
@@ -136,4 +142,5 @@ class AgentNick:
             )
             self.qdrant_client.create_payload_index(collection_name=collection_name, field_name="document_type", field_schema=models.PayloadSchemaType.KEYWORD, wait=True)
             self.qdrant_client.create_payload_index(collection_name=collection_name, field_name="product_type", field_schema=models.PayloadSchemaType.KEYWORD, wait=True)
+            self.qdrant_client.create_payload_index(collection_name=collection_name, field_name="record_id", field_schema=models.PayloadSchemaType.KEYWORD, wait=True)
             logger.info("Collection and payload indexes created successfully.")

--- a/agents/rag_agent.py
+++ b/agents/rag_agent.py
@@ -25,7 +25,7 @@ class RAGAgent(BaseAgent):
             return {"answer": "I could not find any relevant documents to answer your question."}
 
         context = "".join(
-            f"Document ID: {hit.payload.get('record_id', hit.id)}, Score: {hit.score:.2f}\nSummary: {hit.payload.get('summary')}\n---\n"
+            f"Document ID: {hit.payload.get('record_id', hit.id)}, Score: {hit.score:.2f}\nContent: {hit.payload.get('content', hit.payload.get('summary', ''))}\n---\n"
             for hit in search_result
         )
 

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -237,7 +237,45 @@ class Orchestrator:
             logger.error(f"Agent {agent_name} not found")
             return None
 
-        return agent.run(context)
+        result = agent.run(context)
+
+        try:
+            status = 1 if result.status == AgentStatus.SUCCESS else 0
+        except Exception:
+            status = 0
+
+        process_id = None
+        try:
+            process_id = self.agent_nick.process_routing_service.log_process(
+                process_name=agent_name,
+                process_details={
+                    'input': context.input_data,
+                    'output': getattr(result, 'data', None)
+                },
+                process_status=status,
+                user_id=context.user_id,
+                user_name=self.agent_nick.settings.script_user,
+            )
+        except Exception as e:
+            logger.error(f"Routing log failed for {agent_name}: {e}")
+
+        if process_id is not None:
+            try:
+                self.agent_nick.process_routing_service.log_action(
+                    process_id=process_id,
+                    agent_type=agent_name,
+                    action_desc=context.input_data,
+                    process_output=getattr(result, 'data', None),
+                    status=(
+                        "completed"
+                        if result.status == AgentStatus.SUCCESS
+                        else "failed"
+                    ),
+                )
+            except Exception as e:
+                logger.error(f"Action log failed for {agent_name}: {e}")
+
+        return result
 
     def _execute_parallel_agents(self, agents: List[str], context: AgentContext,
                                  pass_fields: Dict) -> Dict:

--- a/services/model_selector.py
+++ b/services/model_selector.py
@@ -113,7 +113,7 @@ class RAGPipeline:
         )
         retrieved_context = "\n---\n".join(
             [
-                f"Document ID: {hit.payload.get('record_id', hit.id)}\nSummary: {hit.payload.get('summary')}"
+                f"Document ID: {hit.payload.get('record_id', hit.id)}\nContent: {hit.payload.get('content', hit.payload.get('summary'))}"
                 for hit in search_results
             ]
         ) if search_results else "No relevant documents found."

--- a/services/process_routing_service.py
+++ b/services/process_routing_service.py
@@ -1,0 +1,160 @@
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessRoutingService:
+    """Service to log agent processing state into proc.routing table."""
+
+    def __init__(self, agent_nick):
+        self.agent_nick = agent_nick
+        self.settings = agent_nick.settings
+
+    def log_process(
+        self,
+        process_name: str,
+        process_details: Dict[str, Any],
+        process_status: int = 1,
+        user_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+        created_by: Optional[str] = None,
+    ) -> Optional[int]:
+        """Insert a process routing record and return the new process_id."""
+        try:
+            with self.agent_nick.get_db_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS proc.routing (
+                            process_id INTEGER NOT NULL DEFAULT nextval('proc.process_process_id_seq'),
+                            process_name TEXT NOT NULL,
+                            process_details JSONB,
+                            process_status INTEGER NOT NULL DEFAULT 1,
+                            created_on TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                            created_by TEXT,
+                            modified_on TIMESTAMP WITHOUT TIME ZONE,
+                            modified_by TEXT,
+                            user_id TEXT,
+                            user_name TEXT,
+                            CONSTRAINT process_pkey PRIMARY KEY (process_id)
+                        )
+                        """
+                    )
+
+                    cursor.execute(
+                        """
+                        INSERT INTO proc.routing
+                            (process_name, process_details, process_status, created_by, user_id, user_name)
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                        RETURNING process_id
+                        """,
+                        (
+                            process_name,
+                            json.dumps(process_details),
+                            process_status,
+                            created_by or self.settings.script_user,
+                            user_id,
+                            user_name,
+                        ),
+                    )
+                    process_id = cursor.fetchone()[0]
+                    conn.commit()
+                    logger.info(
+                        "Logged process %s with id %s", process_name, process_id
+                    )
+                    return process_id
+        except Exception as exc:
+            logger.error("Failed to log process %s: %s", process_name, exc)
+            return None
+
+    def log_action(
+        self,
+        process_id: int,
+        agent_type: str,
+        action_desc: Any,
+        process_output: Optional[Any] = None,
+        status: str = "running",
+        action_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Insert or update an action record in ``proc.action``.
+
+        If ``action_id`` is provided, the existing record is updated with the
+        new ``process_output`` and ``status``. Otherwise a new record is
+        inserted and its ``action_id`` returned.
+        """
+        try:
+            with self.agent_nick.get_db_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS proc.action (
+                            id INTEGER NOT NULL DEFAULT nextval('proc.action_id_seq'),
+                            action_id VARCHAR(100),
+                            process_id VARCHAR(100),
+                            run_id VARCHAR(100),
+                            agent_type VARCHAR(50),
+                            process_output TEXT,
+                            status VARCHAR(50),
+                            action_desc TEXT,
+                            action_date TIMESTAMP WITHOUT TIME ZONE,
+                            created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                            updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                            CONSTRAINT action_pkey PRIMARY KEY (id)
+                        )
+                        """
+                    )
+
+                    if not action_id:
+                        action_id = str(uuid.uuid4())
+                        run_id = run_id or str(uuid.uuid4())
+                        cursor.execute(
+                            """
+                            INSERT INTO proc.action (
+                                action_id, process_id, run_id, agent_type,
+                                process_output, status, action_desc, action_date
+                            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                            """,
+                            (
+                                action_id,
+                                str(process_id),
+                                run_id,
+                                agent_type,
+                                json.dumps(process_output) if process_output is not None else None,
+                                status,
+                                json.dumps(action_desc) if not isinstance(action_desc, str) else action_desc,
+                                datetime.utcnow(),
+                            ),
+                        )
+                    else:
+                        cursor.execute(
+                            """
+                            UPDATE proc.action
+                            SET process_output = %s,
+                                status = %s,
+                                updated_at = CURRENT_TIMESTAMP
+                            WHERE action_id = %s
+                            """,
+                            (
+                                json.dumps(process_output) if process_output is not None else None,
+                                status,
+                                action_id,
+                            ),
+                        )
+                    conn.commit()
+                    logger.info(
+                        "Logged action %s for process %s with status %s",
+                        action_id,
+                        process_id,
+                        status,
+                    )
+                    return action_id
+        except Exception as exc:
+            logger.error(
+                "Failed to log action for process %s: %s", process_id, exc
+            )
+            return None


### PR DESCRIPTION
## Summary
- add ProcessRoutingService to record agent run details in `proc.routing`
- embed full document chunks into Qdrant and index record IDs
- use chunk content during retrieval for more accurate answers
- capture each agent's inputs and outputs in `proc.action` with unique action/run IDs linked to `proc.routing`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895ae417c908332b3d61f7d62cfb1d1