### PR TITLE
Register agents and broaden process logging

### DIFF
--- a/agents/discrepancy_detection_agent.py
+++ b/agents/discrepancy_detection_agent.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 class DiscrepancyDetectionAgent(BaseAgent):
     """Agent for detecting discrepancies in procurement data"""
 
+    def run(self, context: AgentContext) -> AgentOutput:
+        """Execute the discrepancy detection flow."""
+        return self.process(context)
+
     def process(self, context: AgentContext) -> AgentOutput:
         """Process discrepancy detection"""
         try:

--- a/agents/opportunity_miner_agent.py
+++ b/agents/opportunity_miner_agent.py
@@ -9,6 +9,10 @@ logger = logging.getLogger(__name__)
 class OpportunityMinerAgent(BaseAgent):
     """Agent for identifying cost-saving opportunities"""
 
+    def run(self, context: AgentContext) -> AgentOutput:
+        """Execute the opportunity mining flow."""
+        return self.process(context)
+
     def process(self, context: AgentContext) -> AgentOutput:
         """Process opportunity mining"""
         try:

--- a/agents/quote_evaluation_agent.py
+++ b/agents/quote_evaluation_agent.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 class QuoteEvaluationAgent(BaseAgent):
     """Agent for evaluating and comparing supplier quotes"""
 
+    def run(self, context: AgentContext) -> AgentOutput:
+        """Execute the quote evaluation flow."""
+        return self.process(context)
+
     def process(self, context: AgentContext) -> AgentOutput:
         """Process quote evaluation"""
         try:

--- a/api/main.py
+++ b/api/main.py
@@ -12,6 +12,9 @@ from services.model_selector import RAGPipeline
 from agents.base_agent import AgentNick
 from agents.data_extraction_agent import DataExtractionAgent
 from agents.supplier_ranking_agent import SupplierRankingAgent
+from agents.quote_evaluation_agent import QuoteEvaluationAgent
+from agents.opportunity_miner_agent import OpportunityMinerAgent
+from agents.discrepancy_detection_agent import DiscrepancyDetectionAgent
 from api.routers import workflows, system
 
 LOG_DIR = os.path.join(os.path.dirname(__file__), '..', 'logs')
@@ -27,7 +30,10 @@ async def lifespan(app: FastAPI):
         agent_nick = AgentNick()
         agent_nick.agents = {
             'data_extraction': DataExtractionAgent(agent_nick),
-            'supplier_ranking': SupplierRankingAgent(agent_nick)
+            'supplier_ranking': SupplierRankingAgent(agent_nick),
+            'quote_evaluation': QuoteEvaluationAgent(agent_nick),
+            'opportunity_miner': OpportunityMinerAgent(agent_nick),
+            'discrepancy_detection': DiscrepancyDetectionAgent(agent_nick),
         }
         app.state.orchestrator = Orchestrator(agent_nick)
         app.state.rag_pipeline = RAGPipeline(agent_nick)

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -239,6 +239,8 @@ class Orchestrator:
 
         result = agent.run(context)
 
+        agent_label = agent.__class__.__name__
+
         try:
             status = 1 if result.status == AgentStatus.SUCCESS else 0
         except Exception:
@@ -247,7 +249,7 @@ class Orchestrator:
         process_id = None
         try:
             process_id = self.agent_nick.process_routing_service.log_process(
-                process_name=agent_name,
+                process_name=agent_label,
                 process_details={
                     'input': context.input_data,
                     'output': getattr(result, 'data', None)
@@ -257,13 +259,13 @@ class Orchestrator:
                 user_name=self.agent_nick.settings.script_user,
             )
         except Exception as e:
-            logger.error(f"Routing log failed for {agent_name}: {e}")
+            logger.error(f"Routing log failed for {agent_label}: {e}")
 
         if process_id is not None:
             try:
                 self.agent_nick.process_routing_service.log_action(
                     process_id=process_id,
-                    agent_type=agent_name,
+                    agent_type=agent_label,
                     action_desc=context.input_data,
                     process_output=getattr(result, 'data', None),
                     status=(
@@ -273,7 +275,7 @@ class Orchestrator:
                     ),
                 )
             except Exception as e:
-                logger.error(f"Action log failed for {agent_name}: {e}")
+                logger.error(f"Action log failed for {agent_label}: {e}")
 
         return result
 


### PR DESCRIPTION
## Summary
- Register opportunity mining, quote evaluation, and discrepancy detection agents with the API so they participate in orchestrated workflows
- Add `run` wrappers for all agents to unify the execution interface
- Log process and action records using each agent's class name for clearer tracking in `proc.routing` and `proc.action`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895db83b40883329d5b9e64575efb4a