### PR TITLE
feat: speed up ollama responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ boto3
 psycopg2-binary
 ollama
 pdfplumber
+pymupdf
 python-dateutil
 qdrant-client
 sentence-transformers


### PR DESCRIPTION
## Summary
- use `ollama.chat` to generate answers and follow-ups in a single call
- set GPU-friendly env vars and keep models warm for faster responses
- add PyMuPDF fallback and LLM-based document type classifier for data extraction
- upsert extracted invoice or purchase-order headers into PostgreSQL tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689727f772688332b037d4343b908c0e