### PR TITLE
feat: improve RAG agent retrieval

### DIFF
--- a/agents/rag_agent.py
+++ b/agents/rag_agent.py
@@ -36,10 +36,11 @@ class RAGAgent(BaseAgent):
 
         history = self._load_chat_history(user_id)
 
-        # Expand the user's query to improve recall in the vector search stage
-        query_variants = [query] + self._expand_query(query)
         search_hits = []
         seen_ids = set()
+
+        # Expand the user's query to improve recall in the vector search stage
+        query_variants = [query] + self._expand_query(query)
         for q in query_variants:
             q_vec = self.agent_nick.embedding_model.encode(q).tolist()
             hits = self.agent_nick.qdrant_client.search(

--- a/tests/test_data_extraction_agent.py
+++ b/tests/test_data_extraction_agent.py
@@ -29,11 +29,12 @@ def test_vectorize_document_normalizes_labels(monkeypatch):
     )
 
     agent = DataExtractionAgent(nick)
-    monkeypatch.setattr(agent, "_generate_document_summary", lambda *a, **k: "summary")
     monkeypatch.setattr(agent, "_chunk_text", lambda text: [text])
 
-    agent._vectorize_document({}, "hello world", "1", ["Invoice"], ["Hardware"], "doc.pdf")
+    agent._vectorize_document("hello world", "1", ["Invoice"], ["Hardware"], "doc.pdf")
 
     payload = captured["points"][0].payload
     assert payload["document_type"] == "invoice"
     assert payload["product_type"] == "hardware"
+    assert payload["record_id"] == "1"
+    assert payload["content"] == "hello world"

--- a/tests/test_discrepancy_detection_agent.py
+++ b/tests/test_discrepancy_detection_agent.py
@@ -1,0 +1,70 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agents import discrepancy_detection_agent as dd_module
+from agents.base_agent import AgentContext, AgentStatus
+from psycopg2.errors import UndefinedColumn
+
+
+class FakeCursor:
+    def __init__(self, row, raise_undefined=False):
+        self.row = row
+        self.raise_undefined = raise_undefined
+        self.calls = 0
+
+    def execute(self, query, params):
+        self.calls += 1
+        if self.raise_undefined and self.calls == 1:
+            raise UndefinedColumn()
+
+    def fetchone(self):
+        return self.row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def build_agent(cursor):
+    nick = SimpleNamespace(get_db_connection=lambda: FakeConn(cursor), settings=SimpleNamespace())
+    return dd_module.DiscrepancyDetectionAgent(nick)
+
+
+def make_context(doc):
+    return AgentContext(workflow_id="w", agent_id="a", user_id="u", input_data={"extracted_docs": [doc]})
+
+
+def test_fallback_to_vendor_column(monkeypatch):
+    cursor = FakeCursor(("Acme", "2025-01-01", 100.0), raise_undefined=True)
+    agent = build_agent(cursor)
+    out = agent.run(make_context({"doc_type": "Invoice", "id": "1"}))
+    assert out.status == AgentStatus.SUCCESS
+    assert out.data["mismatches"] == []
+
+
+def test_detects_missing_fields(monkeypatch):
+    cursor = FakeCursor((None, None, 0))
+    agent = build_agent(cursor)
+    out = agent.run(make_context({"doc_type": "Invoice", "id": "1"}))
+    assert out.data["mismatches"][0]["checks"]["vendor_name"] == "missing"
+    assert out.data["mismatches"][0]["checks"]["invoice_date"] == "missing"
+    assert out.data["mismatches"][0]["checks"]["total_amount"] == "invalid"

--- a/tests/test_rag_agent.py
+++ b/tests/test_rag_agent.py
@@ -27,3 +27,38 @@ def test_expand_query_parses_llm_response(monkeypatch):
     monkeypatch.setattr(agent, "call_ollama", fake_ollama)
     expansions = agent._expand_query("test query")
     assert expansions == ["alt1", "alt2"]
+
+
+def test_run_returns_search_hits(monkeypatch):
+    monkeypatch.setattr(rag_module, "CrossEncoder", DummyCrossEncoder)
+
+    class DummyEmbed:
+        def encode(self, text):
+            return SimpleNamespace(tolist=lambda: [0.0])
+
+    class DummyQdrant:
+        def search(self, **kwargs):
+            hit = SimpleNamespace(id="1", payload={"record_id": "INV-2025-055", "content": "doc"}, score=1.0)
+            return [hit]
+
+    nick = SimpleNamespace(
+        device="cpu",
+        settings=SimpleNamespace(
+            reranker_model="x",
+            extraction_model="m",
+            qdrant_collection_name="c",
+            s3_bucket_name="b",
+        ),
+        embedding_model=DummyEmbed(),
+        qdrant_client=DummyQdrant(),
+    )
+    agent = rag_module.RAGAgent(nick)
+    monkeypatch.setattr(agent, "_load_chat_history", lambda user_id: [])
+    monkeypatch.setattr(agent, "_save_chat_history", lambda user_id, hist: None)
+    monkeypatch.setattr(agent, "_expand_query", lambda q: [])
+    monkeypatch.setattr(agent, "_generate_followups", lambda q, c: [])
+    monkeypatch.setattr(agent, "_rerank", lambda q, hits, k: hits)
+    monkeypatch.setattr(agent, "call_ollama", lambda p, model=None: {"response": "ans"})
+
+    result = agent.run("details for INV-2025-055", "user")
+    assert result["retrieved_documents"][0]["record_id"] == "INV-2025-055"


### PR DESCRIPTION
## Summary
- ingest documents into the vector store without requiring structured headers
- store raw text chunks with fallback IDs and GPU-based batch embeddings
- drop record-ID specific lookup in RAG agent for more general retrieval
- handle missing vendor columns in discrepancy detection with a vendor fallback and GPU defaults
- add tests ensuring discrepancy detection gracefully checks invoice fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c09bed18c8332984dc6971ed3d2aa