### PR TITLE
Handle aborted transactions in discrepancy detection agent

### DIFF
--- a/tests/test_discrepancy_detection_agent.py
+++ b/tests/test_discrepancy_detection_agent.py
@@ -6,19 +6,22 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents import discrepancy_detection_agent as dd_module
 from agents.base_agent import AgentContext, AgentStatus
-from psycopg2.errors import UndefinedColumn
+from psycopg2.errors import InFailedSqlTransaction, UndefinedColumn
 
 
 class FakeCursor:
-    def __init__(self, row, raise_undefined=False):
+    def __init__(self, row, raise_undefined=False, conn=None):
         self.row = row
         self.raise_undefined = raise_undefined
+        self.conn = conn
         self.calls = 0
 
     def execute(self, query, params):
         self.calls += 1
         if self.raise_undefined and self.calls == 1:
             raise UndefinedColumn()
+        if self.raise_undefined and self.calls > 1 and not self.conn.rollback_called:
+            raise InFailedSqlTransaction()
 
     def fetchone(self):
         return self.row
@@ -31,11 +34,15 @@ class FakeCursor:
 
 
 class FakeConn:
-    def __init__(self, cursor):
-        self._cursor = cursor
+    def __init__(self, row, raise_undefined=False):
+        self.rollback_called = False
+        self._cursor = FakeCursor(row, raise_undefined, self)
 
     def cursor(self):
         return self._cursor
+
+    def rollback(self):
+        self.rollback_called = True
 
     def __enter__(self):
         return self
@@ -44,8 +51,8 @@ class FakeConn:
         pass
 
 
-def build_agent(cursor):
-    nick = SimpleNamespace(get_db_connection=lambda: FakeConn(cursor), settings=SimpleNamespace())
+def build_agent(conn):
+    nick = SimpleNamespace(get_db_connection=lambda: conn, settings=SimpleNamespace())
     return dd_module.DiscrepancyDetectionAgent(nick)
 
 
@@ -54,16 +61,17 @@ def make_context(doc):
 
 
 def test_fallback_to_vendor_column(monkeypatch):
-    cursor = FakeCursor(("Acme", "2025-01-01", 100.0), raise_undefined=True)
-    agent = build_agent(cursor)
+    conn = FakeConn(("Acme", "2025-01-01", 100.0), raise_undefined=True)
+    agent = build_agent(conn)
     out = agent.run(make_context({"doc_type": "Invoice", "id": "1"}))
     assert out.status == AgentStatus.SUCCESS
     assert out.data["mismatches"] == []
+    assert conn.rollback_called
 
 
 def test_detects_missing_fields(monkeypatch):
-    cursor = FakeCursor((None, None, 0))
-    agent = build_agent(cursor)
+    conn = FakeConn((None, None, 0))
+    agent = build_agent(conn)
     out = agent.run(make_context({"doc_type": "Invoice", "id": "1"}))
     assert out.data["mismatches"][0]["checks"]["vendor_name"] == "missing"
     assert out.data["mismatches"][0]["checks"]["invoice_date"] == "missing"


### PR DESCRIPTION
## Summary
- roll back the database connection when an undefined column or other DB error occurs in discrepancy detection
- log DB errors and record them in mismatches to keep processing
- add regression tests for rollback behavior during discrepancy detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c44858efc8332afd030e074447136