### PR TITLE
feat: improve PDF text extraction with OCR, column handling, and doc-type awareness

### DIFF
--- a/tests/test_data_extraction_agent.py
+++ b/tests/test_data_extraction_agent.py
@@ -38,3 +38,41 @@ def test_vectorize_document_normalizes_labels(monkeypatch):
     assert payload["product_type"] == "hardware"
     assert payload["record_id"] == "1"
     assert payload["content"] == "hello world"
+
+
+def test_non_structured_docs_are_vectorized(monkeypatch):
+    """Documents other than POs or invoices should only be vectorized."""
+
+    captured = {}
+
+    # Fake dependencies for the agent
+    import numpy as np
+    from io import BytesIO
+    nick = SimpleNamespace(
+        s3_client=SimpleNamespace(
+            get_object=lambda Bucket, Key: {"Body": BytesIO(b"fake")}
+        ),
+        embedding_model=SimpleNamespace(encode=lambda chunks, **kwargs: [np.zeros(3) for _ in chunks]),
+        qdrant_client=SimpleNamespace(upsert=lambda **kwargs: captured.setdefault("vectorized", True)),
+        _initialize_qdrant_collection=lambda: None,
+        settings=SimpleNamespace(
+            s3_bucket_name="b",
+            s3_prefixes=[],
+            qdrant_collection_name="c",
+            extraction_model="m",
+        ),
+    )
+
+    agent = DataExtractionAgent(nick)
+
+    monkeypatch.setattr(agent, "_extract_text", lambda b, k: "contract text")
+    monkeypatch.setattr(agent, "_classify_doc_type", lambda t: "Contract")
+    monkeypatch.setattr(agent, "_persist_to_postgres", lambda *args, **kwargs: captured.setdefault("persist", True))
+    monkeypatch.setattr(agent, "_vectorize_document", lambda text, pk, dt, pt, key: captured.setdefault("doc_type", dt))
+
+    res = agent._process_single_document("doc.pdf")
+
+    assert captured.get("doc_type") == "Contract"
+    assert "persist" not in captured  # should not attempt DB insert
+    assert res["id"] == "doc.pdf"
+    assert res["doc_type"] == "Contract"


### PR DESCRIPTION
## Summary
- expand document handling to classify files up front and only structure purchase orders and invoices while vectorizing all documents
- add regression test to ensure non-structured docs are vectorized without persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2c164597883329448ed4940b55b92