### PR TITLE
feat: add email drafting endpoint with attachments

### DIFF
--- a/agents/email_drafting_agent.py
+++ b/agents/email_drafting_agent.py
@@ -36,6 +36,7 @@ class EmailDraftingAgent(BaseAgent):
         sender = context.input_data.get(
             "sender", self.agent_nick.settings.ses_default_sender
         )
+        attachments = context.input_data.get("attachments")
 
         if not recipient:
             return AgentOutput(
@@ -48,6 +49,17 @@ class EmailDraftingAgent(BaseAgent):
             response = self.call_ollama(prompt=prompt)
             body = response.get("response", "")
 
-        success = self.email_service.send_email(subject, body or "", recipient, sender)
+        success = self.email_service.send_email(
+            subject, body or "", recipient, sender, attachments
+        )
         status = AgentStatus.SUCCESS if success else AgentStatus.FAILED
-        return AgentOutput(status=status, data={"subject": subject, "body": body, "recipient": recipient, "sender": sender})
+        return AgentOutput(
+            status=status,
+            data={
+                "subject": subject,
+                "body": body,
+                "recipient": recipient,
+                "sender": sender,
+                "attachments": attachments,
+            },
+        )

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -1,6 +1,12 @@
 import logging
+import os
 import smtplib
+from typing import List, Optional, Tuple
+import torch
 from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase
+from email import encoders
 
 
 class EmailService:
@@ -11,19 +17,56 @@ class EmailService:
         self.settings = agent_nick.settings
         self.logger = logging.getLogger(__name__)
 
-    def send_email(self, subject: str, body: str, recipient: str, sender: str) -> bool:
+    def send_email(
+        self,
+        subject: str,
+        body: str,
+        recipient: str,
+        sender: str,
+        attachments: Optional[List[Tuple[bytes, str]]] = None,
+    ) -> bool:
         """Send an email using SMTP credentials configured in settings.
 
+        Attachments should be provided as a list of ``(content, filename)`` tuples.
         Returns True on success, False otherwise.
         """
-        msg = MIMEText(body)
+        # Ensure GPU-related environment variables are set
+        os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
+        os.environ.setdefault("OLLAMA_USE_GPU", "1")
+        os.environ.setdefault(
+            "SENTENCE_TRANSFORMERS_DEFAULT_DEVICE",
+            "cuda" if torch.cuda.is_available() else "cpu",
+        )
+        if torch.cuda.is_available():  # pragma: no cover - hardware dependent
+            torch.set_default_device("cuda")
+        else:  # pragma: no cover - hardware dependent
+            self.logger.warning("CUDA not available; defaulting to CPU.")
+
+        msg = MIMEMultipart()
         msg["Subject"] = subject
         msg["From"] = sender
         msg["To"] = recipient
+        msg.attach(MIMEText(body))
+
+        if attachments:
+            for content, filename in attachments:
+                part = MIMEBase("application", "octet-stream")
+                part.set_payload(content)
+                encoders.encode_base64(part)
+                part.add_header(
+                    "Content-Disposition",
+                    f"attachment; filename=\"{filename}\"",
+                )
+                msg.attach(part)
+
         try:
-            with smtplib.SMTP(self.settings.ses_smtp_endpoint, self.settings.ses_smtp_port) as server:
+            with smtplib.SMTP(
+                self.settings.ses_smtp_endpoint, self.settings.ses_smtp_port
+            ) as server:
                 server.starttls()
-                server.login(self.settings.ses_smtp_user, self.settings.ses_smtp_password)
+                server.login(
+                    self.settings.ses_smtp_user, self.settings.ses_smtp_password
+                )
                 server.sendmail(sender, [recipient], msg.as_string())
             return True
         except Exception as exc:  # pragma: no cover - network/runtime

--- a/tests/test_email_drafting_agent.py
+++ b/tests/test_email_drafting_agent.py
@@ -22,8 +22,14 @@ def test_email_drafting_agent(monkeypatch):
 
     sent = {}
 
-    def fake_send(subject, body, recipient, sender):
-        sent.update({'subject': subject, 'body': body, 'recipient': recipient, 'sender': sender})
+    def fake_send(subject, body, recipient, sender, attachments=None):
+        sent.update({
+            'subject': subject,
+            'body': body,
+            'recipient': recipient,
+            'sender': sender,
+            'attachments': attachments,
+        })
         return True
 
     monkeypatch.setattr(agent.email_service, 'send_email', fake_send)
@@ -32,10 +38,16 @@ def test_email_drafting_agent(monkeypatch):
         workflow_id='wf1',
         agent_id='email_drafting',
         user_id='u1',
-        input_data={'prompt': 'hi', 'subject': 'Sub', 'recipient': 'to@example.com'},
+        input_data={
+            'prompt': 'hi',
+            'subject': 'Sub',
+            'recipient': 'to@example.com',
+            'attachments': [(b'data', 'file.txt')],
+        },
     )
 
     output = agent.run(context)
     assert output.status == AgentStatus.SUCCESS
     assert sent['body'] == 'draft'
     assert sent['subject'] == 'Sub'
+    assert sent['attachments'] == [(b'data', 'file.txt')]


### PR DESCRIPTION
## Summary
- support optional attachments and GPU configuration in email service
- allow EmailDraftingAgent to send attachments and return metadata
- expose `/workflows/email` endpoint for drafting and sending emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3468f2a388332a4ead60f1ec888eb