### PR TITLE
Populate agent line item tables

### DIFF
--- a/agents/opportunity_miner_agent.py
+++ b/agents/opportunity_miner_agent.py
@@ -419,13 +419,11 @@ class OpportunityMinerAgent(BaseAgent):
             return findings
         # Placeholder: assume a 2% discount could have been taken if payment_terms < 30
         for _, row in inv.iterrows():
-            terms = pd.to_numeric(row.get("payment_terms"), errors="coerce")
-            if pd.notna(terms) and 0 < terms <= 15:
             try:
                 terms = int(row.get("payment_terms", 0))
-            except ValueError:
+            except (ValueError, TypeError):
                 terms = 0
-            if terms > 0 and terms <= 15:
+            if 0 < terms <= 15:
                 discount = row["invoice_amount_gbp"] * 0.02
                 findings.append(
                     self._build_finding(


### PR DESCRIPTION
## Summary
- Write invoice line items into `invoice_line_items_agent` with extended fields
- Fix line item extraction prompts and numeric handling
- Handle missing payment terms in opportunity miner

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a79449008332a65eb703e6983acd