### PR TITLE
refactor: centralize GPU configuration

### DIFF
--- a/agents/data_extraction_agent.py
+++ b/agents/data_extraction_agent.py
@@ -36,20 +36,11 @@ from agents.base_agent import (
     AgentOutput,
     AgentStatus,
 )
+from utils.gpu import configure_gpu
 
 logger = logging.getLogger(__name__)
 
-# Ensure GPU is accessible when available
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-os.environ.setdefault("OLLAMA_USE_GPU", "1")
-os.environ.setdefault(
-    "SENTENCE_TRANSFORMERS_DEFAULT_DEVICE",
-    "cuda" if torch.cuda.is_available() else "cpu",
-)
-if torch.cuda.is_available():  # pragma: no cover - hardware dependent
-    torch.set_default_device("cuda")
-else:  # pragma: no cover - hardware dependent
-    logger.warning("CUDA not available; defaulting to CPU.")
+configure_gpu()
 
 HITL_CONFIDENCE_THRESHOLD = 0.85
 
@@ -602,7 +593,7 @@ class DataExtractionAgent(BaseAgent):
 
         # Batch encode the chunks so the GPU can be utilised efficiently.  The
         # embedding model automatically uses the GPU when available via
-        # ``torch.set_default_device`` above.
+        # :func:`utils.gpu.configure_gpu`.
         vectors = self.agent_nick.embedding_model.encode(
             chunks, normalize_embeddings=True, show_progress_bar=False
         )

--- a/agents/discrepancy_detection_agent.py
+++ b/agents/discrepancy_detection_agent.py
@@ -1,25 +1,14 @@
 import logging
-import os
 from typing import Dict, Iterable, List, Optional
 
-import torch
 from psycopg2 import errors
 
 from agents.base_agent import BaseAgent, AgentContext, AgentOutput, AgentStatus
+from utils.gpu import configure_gpu
 
 logger = logging.getLogger(__name__)
 
-# Ensure GPU is accessible when available and downstream libs use it
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-os.environ.setdefault("OLLAMA_USE_GPU", "1")
-os.environ.setdefault(
-    "SENTENCE_TRANSFORMERS_DEFAULT_DEVICE",
-    "cuda" if torch.cuda.is_available() else "cpu",
-)
-if torch.cuda.is_available():  # pragma: no cover - hardware dependent
-    torch.set_default_device("cuda")
-else:  # pragma: no cover - hardware dependent
-    logger.warning("CUDA not available; defaulting to CPU.")
+configure_gpu()
 
 
 class DiscrepancyDetectionAgent(BaseAgent):

--- a/agents/email_drafting_agent.py
+++ b/agents/email_drafting_agent.py
@@ -1,24 +1,12 @@
 import logging
-import os
-
-import torch
 
 from agents.base_agent import BaseAgent, AgentContext, AgentOutput, AgentStatus
 from services.email_service import EmailService
+from utils.gpu import configure_gpu
 
 logger = logging.getLogger(__name__)
 
-# Ensure GPU variables are set
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-os.environ.setdefault("OLLAMA_USE_GPU", "1")
-os.environ.setdefault(
-    "SENTENCE_TRANSFORMERS_DEFAULT_DEVICE",
-    "cuda" if torch.cuda.is_available() else "cpu",
-)
-if torch.cuda.is_available():  # pragma: no cover - hardware dependent
-    torch.set_default_device("cuda")
-else:  # pragma: no cover - hardware dependent
-    logger.warning("CUDA not available; defaulting to CPU.")
+configure_gpu()
 
 
 class EmailDraftingAgent(BaseAgent):

--- a/agents/opportunity_miner_agent.py
+++ b/agents/opportunity_miner_agent.py
@@ -27,6 +27,7 @@ from typing import Dict, Iterable, List, Optional
 import pandas as pd
 
 from agents.base_agent import BaseAgent, AgentContext, AgentOutput, AgentStatus
+from utils.gpu import configure_gpu
 
 logger = logging.getLogger(__name__)
 
@@ -58,17 +59,8 @@ class OpportunityMinerAgent(BaseAgent):
         super().__init__(agent_nick)
         self.min_financial_impact = min_financial_impact
 
-        # ------------------------------------------------------------------
         # GPU configuration
-        # ------------------------------------------------------------------
-        try:  # pragma: no cover - torch is optional for this repository
-            import torch
-
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
-            if self.device == "cuda":
-                os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-        except Exception:  # pragma: no cover - defensive
-            self.device = "cpu"
+        self.device = configure_gpu()
         os.environ.setdefault("PROCWISE_DEVICE", self.device)
         logger.info("OpportunityMinerAgent using device: %s", self.device)
 

--- a/agents/rag_agent.py
+++ b/agents/rag_agent.py
@@ -1,17 +1,13 @@
 import json
-import os
 from concurrent.futures import ThreadPoolExecutor
 from botocore.exceptions import ClientError
 from qdrant_client import models
 from sentence_transformers import CrossEncoder
-import torch
 
 from .base_agent import BaseAgent
+from utils.gpu import configure_gpu
 
-# Ensure GPU variables are set for execution environments that provide CUDA
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-if torch.cuda.is_available():  # pragma: no cover - hardware dependent
-    torch.set_default_device("cuda")
+configure_gpu()
 
 
 class RAGAgent(BaseAgent):

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -1,12 +1,13 @@
 import logging
-import os
 import smtplib
 from typing import List, Optional, Tuple
-import torch
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email import encoders
+from utils.gpu import configure_gpu
+
+configure_gpu()
 
 
 class EmailService:
@@ -30,17 +31,6 @@ class EmailService:
         Attachments should be provided as a list of ``(content, filename)`` tuples.
         Returns True on success, False otherwise.
         """
-        # Ensure GPU-related environment variables are set
-        os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-        os.environ.setdefault("OLLAMA_USE_GPU", "1")
-        os.environ.setdefault(
-            "SENTENCE_TRANSFORMERS_DEFAULT_DEVICE",
-            "cuda" if torch.cuda.is_available() else "cpu",
-        )
-        if torch.cuda.is_available():  # pragma: no cover - hardware dependent
-            torch.set_default_device("cuda")
-        else:  # pragma: no cover - hardware dependent
-            self.logger.warning("CUDA not available; defaulting to CPU.")
 
         msg = MIMEMultipart()
         msg["Subject"] = subject

--- a/services/model_selector.py
+++ b/services/model_selector.py
@@ -2,24 +2,20 @@
 
 import json
 import logging
-import os
 import ollama
 import pdfplumber
 from io import BytesIO
 from botocore.exceptions import ClientError
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Type
 from sentence_transformers import CrossEncoder
-from typing import Type
 from config.settings import settings
 from qdrant_client import models
 from .rag_service import RAGService
+from utils.gpu import configure_gpu
 
 logger = logging.getLogger(__name__)
 
-# Ensure GPU is utilised when available
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-os.environ.setdefault("OLLAMA_USE_GPU", "1")
-os.environ.setdefault("OLLAMA_NUM_PARALLEL", "4")
+configure_gpu()
 
 
 class ChatHistoryManager:

--- a/services/rag_service.py
+++ b/services/rag_service.py
@@ -2,12 +2,10 @@ import os
 import uuid
 from typing import List, Dict, Optional
 
-import torch
 from qdrant_client import models
+from utils.gpu import configure_gpu
 
-
-# Ensure GPU is enabled when available
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
+configure_gpu()
 
 
 class RAGService:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the ProcWise agents framework."""

--- a/utils/gpu.py
+++ b/utils/gpu.py
@@ -1,0 +1,51 @@
+"""GPU configuration utilities for the ProcWise agentic framework.
+
+This module centralises GPU-related environment setup so that all agents
+and services can rely on a single, consistent configuration.  The
+``configure_gpu`` function is idempotent – it will apply settings only
+once and return the detected device (``"cuda"`` or ``"cpu"``).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+try:  # ``torch`` is optional at import time for some environments
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore
+
+_CONFIGURED: bool = False
+_DEVICE: Optional[str] = None
+
+
+def configure_gpu() -> str:
+    """Configure GPU environment variables and default device.
+
+    Returns
+    -------
+    str
+        The device string (``"cuda"`` or ``"cpu"``) that should be used by
+        downstream libraries.
+    """
+    global _CONFIGURED, _DEVICE
+    if _CONFIGURED:
+        return _DEVICE or "cpu"
+
+    # Ensure GPU visibility and enablement for libraries that honour these
+    # environment variables. Defaults are chosen to utilise the first GPU.
+    os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
+    os.environ.setdefault("OLLAMA_USE_GPU", "1")
+
+    if torch is not None and torch.cuda.is_available():  # pragma: no cover - hardware dependent
+        torch.set_default_device("cuda")
+        _DEVICE = "cuda"
+    else:
+        _DEVICE = "cpu"
+
+    # Many libraries such as ``sentence_transformers`` respect this variable.
+    os.environ.setdefault("SENTENCE_TRANSFORMERS_DEFAULT_DEVICE", _DEVICE)
+
+    _CONFIGURED = True
+    return _DEVICE


### PR DESCRIPTION
## Summary
- add `configure_gpu` utility for consistent CUDA/OLLAMA setup
- refactor agents and services to use shared GPU configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4c51008cc8332b537e8b920962d97