### PR TITLE
Ensure Qdrant indexes for quote filtering

### DIFF
--- a/agents/quote_evaluation_agent.py
+++ b/agents/quote_evaluation_agent.py
@@ -113,6 +113,22 @@ class QuoteEvaluationAgent(BaseAgent):
     ) -> List[Dict]:
         """Fetch quotes from Qdrant vector database."""
 
+        def ensure_index(field_name: str) -> None:
+            """Create a Qdrant payload index if it doesn't exist."""
+            try:
+                self.agent_nick.qdrant_client.create_payload_index(
+                    collection_name=self.settings.qdrant_collection_name,
+                    field_name=field_name,
+                    field_schema=models.PayloadSchemaType.KEYWORD,
+                )
+            except Exception as ie:  # pragma: no cover - network dependent
+                logger.debug("Index creation skipped for %s: %s", field_name, ie)
+
+        if supplier_names:
+            ensure_index("supplier_name")
+        if product_category:
+            ensure_index("product_category")
+
         def build_filter(include_supplier: bool = True) -> models.Filter:
             filters = [
                 models.FieldCondition(


### PR DESCRIPTION
## Summary
- Automatically create Qdrant payload indexes for supplier and product category filters in QuoteEvaluationAgent

## Testing
- `pytest` *(fails: NameError: LOADER_DIR not defined)*
- `pytest tests/test_quote_evaluation_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68a738e44fb4833296c186e0c036789c