### PR TITLE
Simplify quote evaluation output and add RFQ email template

### DIFF
--- a/agents/email_drafting_agent.py
+++ b/agents/email_drafting_agent.py
@@ -10,21 +10,42 @@ configure_gpu()
 
 
 class EmailDraftingAgent(BaseAgent):
-    """Agent that drafts an email body using an LLM and sends it via SES."""
+    """Agent that drafts an HTML RFQ email and sends it via SES."""
+
+    TEMPLATE = """<html><body>
+<p>Dear {supplier_contact_name},</p>
+<p>We are requesting a quotation for the following items/services as part of our sourcing process.
+Please complete the table in full to ensure your proposal can be evaluated accurately.</p>
+<table border=\"1\" cellpadding=\"5\" cellspacing=\"0\">
+<tr><th>Item ID</th><th>Description</th><th>UOM</th><th>Qty</th><th>Unit Price (Currency)</th><th>Extended Price</th><th>Delivery Lead Time (days)</th><th>Payment Terms (days)</th><th>Warranty / Support</th><th>Contract Ref</th><th>Comments</th></tr>
+<tr><td>1</td><td>Office Desk (120cm)</td><td>Each</td><td>50</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>2</td><td>Ergonomic Chair</td><td>Each</td><td>50</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>3</td><td>Filing Cabinet (2dr)</td><td>Each</td><td>20</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+</table>
+<p>Please confirm one of the following options:</p>
+<p>[ ] I accept Your Company’s Standard Terms &amp; Conditions
+(<a href=\"https://yourcompany.com/procurement-terms\">https://yourcompany.com/procurement-terms</a>)</p>
+<p>[ ] I wish to proceed under my current contract with Your Company:
+Contract Number [__________]</p>
+<p>Deadline for submission: {deadline}</p>
+<p>Please return the completed table and confirmation via reply to this email.
+For queries, contact {category_manager_name}, {category_manager_title}, {category_manager_email}.</p>
+<p>Thank you for your response. We look forward to your proposal.</p>
+<p>Kind regards,<br/>{your_name}<br/>{your_title}<br/>{your_company}</p>
+</body></html>"""
 
     def __init__(self, agent_nick):
         super().__init__(agent_nick)
         self.email_service = EmailService(agent_nick)
 
     def run(self, context: AgentContext) -> AgentOutput:
-        subject = context.input_data.get("subject", "")
-        prompt = context.input_data.get("prompt")
-        body = context.input_data.get("body")
-        recipient = context.input_data.get("recipient")
-        sender = context.input_data.get(
-            "sender", self.agent_nick.settings.ses_default_sender
+        data = context.input_data
+        subject = data.get(
+            "subject", "Request for Quotation (RFQ) – Office Furniture"
         )
-        attachments = context.input_data.get("attachments")
+        recipient = data.get("recipient")
+        sender = data.get("sender", self.agent_nick.settings.ses_default_sender)
+        attachments = data.get("attachments")
 
         if not recipient:
             return AgentOutput(
@@ -33,21 +54,29 @@ class EmailDraftingAgent(BaseAgent):
                 error="recipient not provided",
             )
 
-        if prompt and not body:
-            response = self.call_ollama(prompt=prompt)
-            body = response.get("response", "")
+        html_body = self.TEMPLATE.format(
+            supplier_contact_name=data.get("supplier_contact_name", "Supplier"),
+            deadline=data.get("submission_deadline", ""),
+            category_manager_name=data.get("category_manager_name", ""),
+            category_manager_title=data.get("category_manager_title", ""),
+            category_manager_email=data.get("category_manager_email", ""),
+            your_name=data.get("your_name", ""),
+            your_title=data.get("your_title", ""),
+            your_company=data.get("your_company", ""),
+        )
 
         success = self.email_service.send_email(
-            subject, body or "", recipient, sender, attachments
+            subject, html_body, recipient, sender, attachments
         )
         status = AgentStatus.SUCCESS if success else AgentStatus.FAILED
         return AgentOutput(
             status=status,
             data={
                 "subject": subject,
-                "body": body,
+                "body": html_body,
                 "recipient": recipient,
                 "sender": sender,
                 "attachments": attachments,
             },
         )
+

--- a/agents/quote_evaluation_agent.py
+++ b/agents/quote_evaluation_agent.py
@@ -1,109 +1,68 @@
-import json
 import logging
-import os
 from typing import Dict, List, Optional
 
 import numpy as np
-import pandas as pd
-import torch
 from qdrant_client import models
 
 from agents.base_agent import BaseAgent, AgentContext, AgentOutput, AgentStatus
+from utils.gpu import configure_gpu
 
-# Ensure GPU is used when available
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
-os.environ.setdefault("OLLAMA_USE_GPU", "1")
-os.environ.setdefault("OLLAMA_NUM_PARALLEL", "4")
-os.environ.setdefault("OMP_NUM_THREADS", "8")
-if torch.cuda.is_available():  # pragma: no cover - hardware dependent
-    torch.set_default_device("cuda")
+# Ensure GPU configuration is applied
+configure_gpu()
 
 logger = logging.getLogger(__name__)
 
 
 class QuoteEvaluationAgent(BaseAgent):
-    """Agent for evaluating and comparing supplier quotes"""
+    """Agent for retrieving and exposing quote data from Qdrant."""
 
     def run(self, context: AgentContext) -> AgentOutput:
-        """Execute the quote evaluation flow."""
         return self.process(context)
 
     def process(self, context: AgentContext) -> AgentOutput:
-        """Process quote evaluation"""
+        """Fetch quotes and return only required commercial fields."""
         try:
             input_data = context.input_data
-
-            # Fetch quotes from database
             product_category = (
-                input_data.get('product_category')
-                or input_data.get('product_type')
+                input_data.get("product_category")
+                or input_data.get("product_type")
                 or None
             )
             quotes = self._fetch_quotes(
-                input_data.get('supplier_names', []),
+                input_data.get("supplier_names", []),
                 product_category,
             )
 
             if not quotes:
                 return AgentOutput(
                     status=AgentStatus.FAILED,
-                    data={'message': 'No quotes found'},
-                    error='No quotes to evaluate'
+                    data={"message": "No quotes found"},
+                    error="No quotes to evaluate",
                 )
 
-            # Evaluate quotes
-            evaluation = self._evaluate_quotes(quotes)
-
-            # Generate comparison matrix
-            comparison = self._generate_comparison(quotes)
-
-            # Identify best quote
-            best_quote = self._identify_best_quote(evaluation)
-
-            # Generate recommendations using Ollama
-            recommendations = self._generate_recommendations(
-                best_quote, evaluation, comparison
-            )
-
-            output_data = self._to_native(
-                {
-                    'quotes_analyzed': len(quotes),
-                    'best_quote': best_quote,
-                    'comparison_matrix': comparison,
-                    'evaluation_scores': evaluation,
-                    'recommendations': recommendations,
-                    'savings_potential': self._calculate_savings(quotes, best_quote),
-                }
-            )
-
-            # Determine next agents
-            next_agents = []
-            if best_quote.get('total_amount', 0) > 50000:
-                next_agents.append('HumanEscalationAgent')
-            if output_data['savings_potential'] > 10000:
-                next_agents.append('ContractIntelligenceAgent')
-            if best_quote.get('negotiation_possible'):
-                next_agents.append('NegotiationAgent')
+            simplified: List[Dict] = []
+            for q in quotes:
+                simplified.append(
+                    {
+                        "total_spend": q.get("total_spend", q.get("total_amount")),
+                        "tenure": q.get("tenure") or q.get("payment_terms"),
+                        "total_cost": q.get("total_cost", q.get("total_amount")),
+                        "unit_price": q.get("unit_price", q.get("avg_unit_price")),
+                        "volume": q.get("volume", q.get("line_items_count")),
+                        "quote_file_s3_path": q.get("quote_file_s3_path") or q.get("s3_path"),
+                    }
+                )
 
             return AgentOutput(
                 status=AgentStatus.SUCCESS,
-                data=output_data,
-                next_agents=next_agents,
-                pass_fields={
-                    'selected_quote': best_quote.get('quote_id'),
-                    'supplier': best_quote.get('supplier_name'),
-                    'savings_potential': output_data['savings_potential'],
-                    'negotiation_points': recommendations.get('negotiation_points', [])
-                },
-                confidence=0.85
+                data=self._to_native({"quotes": simplified}),
             )
-
-        except Exception as e:
-            logger.error(f"QuoteEvaluationAgent error: {e}")
+        except Exception as exc:
+            logger.error("QuoteEvaluationAgent error: %s", exc)
             return AgentOutput(
                 status=AgentStatus.FAILED,
                 data={},
-                error=str(e)
+                error=str(exc),
             )
 
     def _fetch_quotes(
@@ -114,7 +73,6 @@ class QuoteEvaluationAgent(BaseAgent):
         """Fetch quotes from Qdrant vector database."""
 
         def ensure_index(field_name: str) -> None:
-            """Create a Qdrant payload index if it doesn't exist."""
             try:
                 self.agent_nick.qdrant_client.create_payload_index(
                     collection_name=self.settings.qdrant_collection_name,
@@ -169,26 +127,8 @@ class QuoteEvaluationAgent(BaseAgent):
             try:
                 points, _ = qdrant_scroll(build_filter(include_supplier=False))
             except Exception as e2:
-                logger.error(f"Failed to fetch quotes from Qdrant: {e2}")
-                # Return mock data for testing
-                return [
-                    {
-                        "quote_id": "Q001",
-                        "supplier_name": "Supplier A",
-                        "total_amount": 45000,
-                        "payment_terms": "Net 30",
-                        "delivery_terms": "5 days",
-                        "discount_percentage": 5,
-                    },
-                    {
-                        "quote_id": "Q002",
-                        "supplier_name": "Supplier B",
-                        "total_amount": 42000,
-                        "payment_terms": "Net 45",
-                        "delivery_terms": "7 days",
-                        "discount_percentage": 8,
-                    },
-                ]
+                logger.error("Failed to fetch quotes from Qdrant: %s", e2)
+                return []
 
         quotes: List[Dict] = []
         for point in points:
@@ -197,232 +137,20 @@ class QuoteEvaluationAgent(BaseAgent):
                 {
                     "quote_id": payload.get("quote_id", point.id),
                     "supplier_name": payload.get("supplier_name", ""),
-                    "customer_name": payload.get("customer_name"),
-                    "quote_date": payload.get("quote_date"),
-                    "valid_until": payload.get("valid_until"),
-                    "total_amount": payload.get("total_amount", 0),
-                    "currency": payload.get("currency"),
+                    "total_spend": payload.get("total_spend", payload.get("total_amount", 0)),
+                    "tenure": payload.get("tenure"),
+                    "total_cost": payload.get("total_cost", payload.get("total_amount", 0)),
+                    "unit_price": payload.get("unit_price", payload.get("avg_unit_price", 0)),
+                    "volume": payload.get("volume", payload.get("line_items_count", 0)),
+                    "quote_file_s3_path": payload.get("quote_file_s3_path")
+                    or payload.get("s3_path"),
                     "payment_terms": payload.get("payment_terms"),
-                    "delivery_terms": payload.get("delivery_terms"),
-                    "discount_percentage": payload.get("discount_percentage", 0),
-                    "line_items_count": payload.get("line_items_count", 0),
-                    "avg_unit_price": payload.get("avg_unit_price", 0),
-                    # Baseline fields for variance detection
-                    "baseline_total_amount": payload.get("baseline_total_amount"),
-                    "baseline_payment_terms": payload.get("baseline_payment_terms"),
+                    "avg_unit_price": payload.get("avg_unit_price"),
+                    "line_items_count": payload.get("line_items_count"),
+                    "total_amount": payload.get("total_amount"),
                 }
             )
         return quotes
-
-    def _evaluate_quotes(self, quotes: List[Dict]) -> Dict:
-        """Evaluate quotes on multiple criteria"""
-        evaluation = {}
-
-        for quote in quotes:
-            quote_id = quote['quote_id']
-
-            # Score different aspects
-            price_score = self._score_price(quote, quotes)
-            terms_score = self._score_terms(quote)
-            delivery_score = self._score_delivery(quote)
-            discount_score = quote.get('discount_percentage', 0) / 10
-
-            # Baseline variance detection
-            variances = self._detect_variances(quote)
-
-            # Calculate overall score (0-10) for backwards compatibility
-            overall_score = (
-                price_score * 0.4 +
-                terms_score * 0.2 +
-                delivery_score * 0.2 +
-                discount_score * 0.2
-            )
-
-            # Supplier ranking score (0-100)
-            price_component = price_score * 10
-            terms_component = terms_score * 10
-            accuracy_component = quote.get('transactional_accuracy', 10) * 10
-            supplier_score = (
-                price_component * 0.7 +
-                terms_component * 0.2 +
-                accuracy_component * 0.1
-            )
-
-            evaluation[quote_id] = {
-                'supplier_name': quote['supplier_name'],
-                'price_score': price_score,
-                'terms_score': terms_score,
-                'delivery_score': delivery_score,
-                'discount_score': discount_score,
-                'overall_score': overall_score,
-                'total_amount': quote['total_amount'],
-                'price_variance': variances.get('price_variance'),
-                'term_variance': variances.get('term_variance'),
-                'total_cost_variance': variances.get('total_cost_variance'),
-                'supplier_score': supplier_score,
-                'opportunity_value': variances.get('opportunity_value'),
-            }
-
-        return evaluation
-
-    def _detect_variances(self, quote: Dict) -> Dict:
-        """Detect variances against baseline information."""
-        baseline_total = quote.get('baseline_total_amount')
-        price_variance = None
-        total_cost_variance = None
-        opportunity_value = 0.0
-        if baseline_total and baseline_total > 0:
-            price_variance = (
-                (quote.get('total_amount', 0) - baseline_total) / baseline_total
-            ) * 100
-            total_cost_variance = price_variance
-            opportunity_value = max(0.0, baseline_total - quote.get('total_amount', 0))
-
-        term_variance = 0
-        baseline_terms = quote.get('baseline_payment_terms')
-        if baseline_terms:
-            term_variance = 0 if quote.get('payment_terms') == baseline_terms else 1
-
-        return {
-            'price_variance': price_variance,
-            'term_variance': term_variance,
-            'total_cost_variance': total_cost_variance,
-            'opportunity_value': opportunity_value,
-        }
-
-    def _score_price(self, quote: Dict, all_quotes: List[Dict]) -> float:
-        """Score quote based on price"""
-        amounts = [q['total_amount'] for q in all_quotes]
-        min_amount = min(amounts)
-        max_amount = max(amounts)
-
-        if max_amount == min_amount:
-            return 10.0
-
-        # Lower price = higher score
-        normalized = (max_amount - quote['total_amount']) / (max_amount - min_amount)
-        return normalized * 10
-
-    def _score_terms(self, quote: Dict) -> float:
-        """Score payment terms"""
-        terms = quote.get('payment_terms', '')
-
-        terms_scores = {
-            'Net 30': 10,
-            'Net 45': 8,
-            'Net 60': 6,
-            'Net 90': 4,
-            'Immediate': 2
-        }
-
-        for term, score in terms_scores.items():
-            if term in terms:
-                return score
-
-        return 5  # Default score
-
-    def _score_delivery(self, quote: Dict) -> float:
-        """Score delivery terms"""
-        delivery = quote.get('delivery_terms', '')
-
-        # Extract days from delivery terms
-        import re
-        days_match = re.search(r'(\d+)\s*day', delivery.lower())
-
-        if days_match:
-            days = int(days_match.group(1))
-            if days <= 3:
-                return 10
-            elif days <= 7:
-                return 8
-            elif days <= 14:
-                return 6
-            else:
-                return 4
-
-        return 5  # Default score
-
-    def _generate_comparison(self, quotes: List[Dict]) -> Dict:
-        """Generate comparison matrix"""
-        if not quotes:
-            return {}
-
-        df = pd.DataFrame(quotes)
-
-        comparison = {
-            'price_range': {
-                'min': df['total_amount'].min(),
-                'max': df['total_amount'].max(),
-                'mean': df['total_amount'].mean(),
-                'std': df['total_amount'].std()
-            },
-            'suppliers': df['supplier_name'].tolist(),
-            'best_payment_terms': df.loc[
-                df['payment_terms'].notna(), 'payment_terms'].value_counts().to_dict() if 'payment_terms' in df else {},
-            'discount_range': {
-                'min': df['discount_percentage'].min() if 'discount_percentage' in df else 0,
-                'max': df['discount_percentage'].max() if 'discount_percentage' in df else 0
-            }
-        }
-
-        return comparison
-
-    def _identify_best_quote(self, evaluation: Dict) -> Dict:
-        """Identify the best quote based on evaluation"""
-        if not evaluation:
-            return {}
-
-        # Find quote with highest overall score
-        best_quote_id = max(evaluation.keys(),
-                            key=lambda k: evaluation[k]['overall_score'])
-
-        best_quote = evaluation[best_quote_id].copy()
-        best_quote['quote_id'] = best_quote_id
-        best_quote['negotiation_possible'] = best_quote['overall_score'] < 8
-
-        return best_quote
-
-    def _calculate_savings(self, quotes: List[Dict], best_quote: Dict) -> float:
-        """Calculate potential savings"""
-        if not quotes or not best_quote:
-            return 0
-
-        amounts = [q['total_amount'] for q in quotes]
-        avg_amount = sum(amounts) / len(amounts)
-
-        savings = avg_amount - best_quote.get('total_amount', avg_amount)
-        return max(0, savings)
-
-    def _generate_recommendations(self, best_quote: Dict,
-                                  evaluation: Dict, comparison: Dict) -> Dict:
-        """Generate recommendations using Ollama"""
-        prompt = f"""Based on the quote evaluation, provide procurement recommendations:
-
-        Best Quote: {json.dumps(best_quote, indent=2)}
-        Price Range: ${comparison.get('price_range', {}).get('min', 0):.2f} - ${comparison.get('price_range', {}).get('max', 0):.2f}
-        Number of Quotes: {len(evaluation)}
-
-        Provide:
-        1. Key decision factors
-        2. Negotiation points (if score < 8)
-        3. Risk considerations
-        4. Final recommendation
-
-        Format as JSON with keys: decision_factors, negotiation_points, risks, recommendation"""
-
-        response = self.call_ollama(prompt, format='json')
-
-        try:
-            recommendations = json.loads(response.get('response', '{}'))
-        except:
-            recommendations = {
-                'decision_factors': ['Price competitiveness', 'Payment terms'],
-                'negotiation_points': ['Volume discount', 'Payment terms improvement'],
-                'risks': ['Supplier reliability', 'Market volatility'],
-                'recommendation': 'Proceed with best quote after negotiation'
-            }
-
-        return recommendations
 
     def _to_native(self, obj):
         """Recursively convert numpy types to native Python types."""
@@ -433,3 +161,4 @@ class QuoteEvaluationAgent(BaseAgent):
         if isinstance(obj, np.generic):
             return obj.item()
         return obj
+

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -36,7 +36,7 @@ class EmailService:
         msg["Subject"] = subject
         msg["From"] = sender
         msg["To"] = recipient
-        msg.attach(MIMEText(body))
+        msg.attach(MIMEText(body, "html"))
 
         if attachments:
             for content, filename in attachments:

--- a/tests/test_email_drafting_agent.py
+++ b/tests/test_email_drafting_agent.py
@@ -3,7 +3,6 @@ import sys
 from types import SimpleNamespace
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from agents.email_drafting_agent import EmailDraftingAgent
 from agents.base_agent import AgentContext, AgentStatus
 
@@ -16,9 +15,6 @@ class DummyNick:
 def test_email_drafting_agent(monkeypatch):
     nick = DummyNick()
     agent = EmailDraftingAgent(nick)
-
-    # Mock LLM response
-    monkeypatch.setattr(agent, 'call_ollama', lambda prompt=None, **kwargs: {'response': 'draft'})
 
     sent = {}
 
@@ -39,15 +35,21 @@ def test_email_drafting_agent(monkeypatch):
         agent_id='email_drafting',
         user_id='u1',
         input_data={
-            'prompt': 'hi',
-            'subject': 'Sub',
             'recipient': 'to@example.com',
+            'supplier_contact_name': 'John',
+            'submission_deadline': '01/01/2025',
+            'category_manager_name': 'Cat',
+            'category_manager_title': 'Mgr',
+            'category_manager_email': 'cat@example.com',
+            'your_name': 'Buyer',
+            'your_title': 'Procurement',
+            'your_company': 'Your Company',
             'attachments': [(b'data', 'file.txt')],
         },
     )
 
     output = agent.run(context)
     assert output.status == AgentStatus.SUCCESS
-    assert sent['body'] == 'draft'
-    assert sent['subject'] == 'Sub'
+    assert '<html>' in sent['body']
+    assert sent['subject'] == 'Request for Quotation (RFQ) – Office Furniture'
     assert sent['attachments'] == [(b'data', 'file.txt')]


### PR DESCRIPTION
## Summary
- streamline QuoteEvaluationAgent to pull quote data from Qdrant and expose only spend, tenure, cost, unit price, volume and S3 path
- implement procurement RFQ HTML template in EmailDraftingAgent and send via SES as HTML
- adjust tests for updated quote evaluation flow and email drafting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad674e905c8332b66d14c2f1287887