### PR TITLE
feat: improve context-aware data persistence

### DIFF
--- a/agents/data_extraction_agent.py
+++ b/agents/data_extraction_agent.py
@@ -912,8 +912,10 @@ class DataExtractionAgent(BaseAgent):
             "tax_percent",
             "tax_amount",
             "line_total",
+            "line_amount",
             "total_with_tax",
             "total_amount",
+            "total_amount_incl_tax",
             "total",
             "invoice_amount",
             "invoice_total_incl_tax",
@@ -925,8 +927,14 @@ class DataExtractionAgent(BaseAgent):
             "due_date",
             "po_date",
             "requested_date",
+            "invoice_paid_date",
+            "delivery_date",
+            "order_date",
+            "expected_delivery_date",
+            "created_date",
+            "last_modified_date",
         }
-        currency_fields = {"currency"}
+        currency_fields = {"currency", "default_currency"}
         if key:
             lower = key.lower()
             if lower in numeric_fields:
@@ -966,8 +974,8 @@ class DataExtractionAgent(BaseAgent):
         self, header: Dict[str, str], doc_type: str, conn=None
     ) -> None:
         table_map = {
-            "Invoice": ("proc", "invoice_agent", "invoice_id"),
-            "Purchase_Order": ("proc", "purchase_order_agent", "po_id"),
+            "Invoice": ("proc", "invoice", "invoice_id"),
+            "Purchase_Order": ("proc", "purchase_order", "po_id"),
         }
         target = table_map.get(doc_type)
         if not target:
@@ -1049,41 +1057,41 @@ class DataExtractionAgent(BaseAgent):
         conn=None,
     ) -> None:
         table_map = {
-            "Invoice": ("proc", "invoice_line_items_agent", "invoice_id", "line_no"),
+            "Invoice": ("proc", "invoice_line_items", "invoice_id", "line_no"),
             "Purchase_Order": (
                 "proc",
-                "po_line_items_agent",
+                "purchase_order_line_items",
                 "po_id",
                 "line_number",
             ),
         }
         field_map = {
-            "Invoice": [
-                "item_id",
-                "item_description",
-                "quantity",
-                "unit_of_measure",
-                "unit_price",
-                "line_amount",
-                "tax_percent",
-                "tax_amount",
-                "total_amount_incl_tax",
-            ],
-            "Purchase_Order": [
-                "item_id",
-                "item_description",
-                "quantity",
-                "unit_price",
-                "unit_of_measure",
-                "currency",
-                "line_total",
-                "tax_percent",
-                "tax_amount",
-                "total_amount",
-            ],
+            "Invoice": {
+                "item_id": "item_id",
+                "item_description": "item_description",
+                "quantity": "quantity",
+                "unit_of_measure": "unit_of_measure",
+                "unit_price": "unit_price",
+                "line_amount": "line_amount",
+                "tax_percent": "tax_percent",
+                "tax_amount": "tax_amount",
+                "total_amount_incl_tax": "total_amount_incl_tax",
+            },
+            "Purchase_Order": {
+                "item_id": "item_id",
+                "item_description": "item_description",
+                "quantity": "quantity",
+                "unit_price": "unit_price",
+                "unit_of_measue": "unit_of_measure",
+                "currency": "currency",
+                "line_total": "line_total",
+                "tax_percent": "tax_percent",
+                "tax_amount": "tax_amount",
+                "total_amount": "total_amount",
+            },
         }
         target = table_map.get(doc_type)
-        fields = field_map.get(doc_type, [])
+        field_map = field_map.get(doc_type, {})
         if not target or not line_items:
             return
         schema, table, fk_col, line_no_col = target
@@ -1135,11 +1143,11 @@ class DataExtractionAgent(BaseAgent):
                         payload.setdefault("po_line_id", f"{pk_value}-{line_value}")
                     if doc_type == "Invoice" and "invoice_line_id" in columns:
                         payload.setdefault("invoice_line_id", f"{pk_value}-{line_value}")
-                    for key in fields:
-                        if key in payload:
+                    for col, source in field_map.items():
+                        if col in payload:
                             continue
-                        if key in columns and item.get(key) is not None:
-                            payload[key] = item[key]
+                        if col in columns and item.get(source) is not None:
+                            payload[col] = item[source]
                     sanitized = {}
                     for k, v in payload.items():
                         val = self._sanitize_value(v, k)

--- a/api/routers/agents.py
+++ b/api/routers/agents.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import logging
 import os
 from pydantic import BaseModel
@@ -68,6 +68,20 @@ async def reload_policies(agent_nick=Depends(get_agent_nick)):
 class AgentExecutionRequest(BaseModel):
     agent_type: str
     payload: Dict[str, Any] = {}
+
+
+class DocumentProcessRequest(BaseModel):
+    s3_prefix: Optional[str] = None
+    s3_object_key: Optional[str] = None
+
+
+@router.post("/process-document")
+def process_document(
+    req: DocumentProcessRequest, orchestrator: Orchestrator = Depends(get_orchestrator)
+):
+    """Convenience endpoint to run the document extraction workflow."""
+    payload = {"s3_prefix": req.s3_prefix, "s3_object_key": req.s3_object_key}
+    return orchestrator.execute_workflow("document_extraction", payload)
 
 
 @router.post("/execute")

--- a/tests/test_data_extraction_agent.py
+++ b/tests/test_data_extraction_agent.py
@@ -121,3 +121,54 @@ def test_contextual_field_normalisation():
     assert normalised_items[0]["item_description"] == "Widget"
     assert normalised_items[0]["quantity"] == "2"
     assert normalised_items[0]["unit_price"] == "5"
+
+
+def test_po_line_items_unit_mapping(monkeypatch):
+    executed = []
+
+    class DummyCursor:
+        def execute(self, sql, params=None):
+            executed.append((sql, params))
+
+        def fetchall(self):
+            return [
+                ("po_line_id",),
+                ("po_id",),
+                ("line_number",),
+                ("unit_of_measue",),
+                ("quantity",),
+            ]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    nick = SimpleNamespace(
+        get_db_connection=lambda: DummyConn(),
+        settings=SimpleNamespace(extraction_model="m"),
+    )
+    agent = DataExtractionAgent(nick)
+
+    item = {"unit_of_measure": "pcs", "quantity": "1"}
+    agent._persist_line_items_to_postgres(
+        "PO1", [item], "Purchase_Order", {}, None
+    )
+
+    insert_sql, params = executed[-1]
+    assert "unit_of_measue" in insert_sql
+    assert "pcs" in params

--- a/tests/test_rag_agent.py
+++ b/tests/test_rag_agent.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from agents import rag_agent as rag_module
+
+
+class DummyCrossEncoder:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def predict(self, pairs):
+        return [0.0 for _ in pairs]
+
+
+def test_rag_agent_applies_filters(monkeypatch):
+    monkeypatch.setattr(rag_module, "CrossEncoder", DummyCrossEncoder)
+
+    captured = {}
+
+    class DummyRAGService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def search(self, query, top_k=5, filters=None):
+            captured["filters"] = filters
+            return []
+
+    monkeypatch.setattr(rag_module, "RAGService", DummyRAGService)
+
+    nick = SimpleNamespace(
+        device="cpu",
+        settings=SimpleNamespace(reranker_model="dummy"),
+        qdrant_client=SimpleNamespace(),
+        embedding_model=SimpleNamespace(),
+    )
+    agent = rag_module.RAGAgent(nick)
+    agent._expand_query = lambda q: []
+    agent._load_chat_history = lambda u: []
+    agent._save_chat_history = lambda u, h: None
+    agent.call_ollama = lambda prompt, model: {"response": "ans"}
+    agent._generate_followups = lambda q, c: []
+
+    agent.run("q", "u", doc_type="Invoice")
+
+    flt = captured.get("filters")
+    assert flt is not None
+    assert flt.must[0].key == "document_type"
+    assert flt.must[0].match.value == "invoice"


### PR DESCRIPTION
## Summary
- normalize header and line item fields for invoices and purchase orders
- add tests for contextual field mapping in the data extraction agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b549bc85f48332bceb20311082a9e9