### PR TITLE
feat: add run endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -23,7 +23,7 @@ from agents.email_drafting_agent import EmailDraftingAgent
 from agents.negotiation_agent import NegotiationAgent
 from agents.approvals_agent import ApprovalsAgent
 from agents.supplier_interaction_agent import SupplierInteractionAgent
-from api.routers import workflows, system
+from api.routers import workflows, system, run
 
 LOG_DIR = os.path.join(os.path.dirname(__file__), '..', 'logs')
 os.makedirs(LOG_DIR, exist_ok=True)
@@ -63,6 +63,7 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, 
 
 app.include_router(workflows.router)
 app.include_router(system.router)
+app.include_router(run.router)
 
 @app.get("/", tags=["General"])
 def read_root(): return {"message": "Welcome to the ProcWise Agentic System API"}

--- a/api/routers/run.py
+++ b/api/routers/run.py
@@ -1,0 +1,37 @@
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from orchestration.orchestrator import Orchestrator
+
+# Ensure GPU-related environment variables are set
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
+os.environ.setdefault("OLLAMA_USE_GPU", "1")
+os.environ.setdefault("OLLAMA_NUM_PARALLEL", "4")
+os.environ.setdefault("OMP_NUM_THREADS", "8")
+
+router = APIRouter(tags=["Run"], prefix="")
+
+
+def get_orchestrator(request: Request) -> Orchestrator:
+    orchestrator = getattr(request.app.state, "orchestrator", None)
+    if not orchestrator:
+        raise HTTPException(status_code=503, detail="Orchestrator service is not available.")
+    return orchestrator
+
+
+class RunRequest(BaseModel):
+    workflow: str
+    payload: Dict[str, Any] = {}
+    user_id: Optional[str] = None
+
+
+@router.post("/run")
+def run_agents(
+    req: RunRequest,
+    orchestrator: Orchestrator = Depends(get_orchestrator),
+):
+    """Execute a workflow using the orchestrator."""
+    return orchestrator.execute_workflow(req.workflow, req.payload, user_id=req.user_id)

--- a/tests/test_run_endpoint.py
+++ b/tests/test_run_endpoint.py
@@ -1,0 +1,55 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api.routers.run import router as run_router
+
+
+class DummyPRS:
+    def log_process(self, **kwargs):
+        return 1
+
+    def log_action(self, **kwargs):
+        return kwargs.get("action_id", "a1")
+
+    def update_process_status(self, *args, **kwargs):
+        pass
+
+
+class DummyOrchestrator:
+    def __init__(self):
+        self.agent_nick = SimpleNamespace(process_routing_service=DummyPRS())
+
+    def execute_workflow(self, workflow_name, input_data, user_id=None):
+        return {
+            "status": "completed",
+            "workflow_id": "wf",
+            "result": {
+                "echo": input_data,
+                "workflow": workflow_name,
+                "user": user_id,
+            },
+        }
+
+
+def test_run_endpoint_executes_workflow():
+    app = FastAPI()
+    app.include_router(run_router)
+    orchestrator = DummyOrchestrator()
+    app.state.orchestrator = orchestrator
+    client = TestClient(app)
+
+    resp = client.post(
+        "/run", json={"workflow": "test", "payload": {"foo": "bar"}, "user_id": "u1"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["result"]["echo"]["foo"] == "bar"
+    assert data["result"]["workflow"] == "test"
+    assert data["result"]["user"] == "u1"


### PR DESCRIPTION
## Summary
- expose `/run` endpoint to invoke orchestrator workflows
- register new router and cover with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5777ce55c8332af2fbae2e18c2960