### PR TITLE
Add vector-only agent and update table mappings

### DIFF
--- a/agents/data_extraction_agent.py
+++ b/agents/data_extraction_agent.py
@@ -974,8 +974,8 @@ class DataExtractionAgent(BaseAgent):
         self, header: Dict[str, str], doc_type: str, conn=None
     ) -> None:
         table_map = {
-            "Invoice": ("proc", "invoice", "invoice_id"),
-            "Purchase_Order": ("proc", "purchase_order", "po_id"),
+            "Invoice": ("proc", "invoice_agent", "invoice_id"),
+            "Purchase_Order": ("proc", "purchase_order_agent", "po_id"),
         }
         target = table_map.get(doc_type)
         if not target:
@@ -1057,10 +1057,10 @@ class DataExtractionAgent(BaseAgent):
         conn=None,
     ) -> None:
         table_map = {
-            "Invoice": ("proc", "invoice_line_items", "invoice_id", "line_no"),
+            "Invoice": ("proc", "invoice_line_items_agent", "invoice_id", "line_no"),
             "Purchase_Order": (
                 "proc",
-                "purchase_order_line_items",
+                "po_line_items_agent",
                 "po_id",
                 "line_number",
             ),

--- a/agents/document_vector_agent.py
+++ b/agents/document_vector_agent.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import os
+from typing import Dict, List, Optional
+
+from agents.data_extraction_agent import DataExtractionAgent
+from agents.base_agent import AgentContext, AgentOutput, AgentStatus
+from utils.gpu import configure_gpu
+
+configure_gpu()
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentVectorAgent(DataExtractionAgent):
+    """Agent dedicated to vectorising documents without structural parsing.
+
+    The agent downloads documents from the configured S3 bucket, extracts the
+    raw text and upserts embeddings into the vector store.  No attempt is made
+    to parse headers or line items; this agent is solely responsible for
+    enabling Retrieval Augmented Generation.
+    """
+
+    def run(self, context: AgentContext) -> AgentOutput:
+        try:
+            s3_prefix = context.input_data.get("s3_prefix")
+            s3_object_key = context.input_data.get("s3_object_key")
+            details = self._process_documents_vector_only(s3_prefix, s3_object_key)
+            return AgentOutput(status=AgentStatus.SUCCESS, data={"status": "completed", "details": details})
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("DocumentVectorAgent failed: %s", exc)
+            return AgentOutput(status=AgentStatus.FAILED, data={}, error=str(exc))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _process_documents_vector_only(
+        self, s3_prefix: str | None = None, s3_object_key: str | None = None
+    ) -> List[Dict[str, str]]:
+        """Process documents and store only their embeddings."""
+        results: List[Dict[str, str]] = []
+        prefixes = [s3_prefix] if s3_prefix else self.settings.s3_prefixes
+        keys: List[str] = []
+        for prefix in prefixes:
+            if s3_object_key and s3_object_key.startswith(prefix):
+                keys.append(s3_object_key)
+            else:
+                resp = self.agent_nick.s3_client.list_objects_v2(
+                    Bucket=self.settings.s3_bucket_name, Prefix=prefix
+                )
+                keys.extend(obj["Key"] for obj in resp.get("Contents", []))
+        supported_exts = {".pdf", ".doc", ".docx", ".png", ".jpg", ".jpeg"}
+        keys = [k for k in keys if os.path.splitext(k)[1].lower() in supported_exts]
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count() or 4) as executor:
+            futures = [executor.submit(self._vectorize_single_document, k) for k in keys]
+            for fut in concurrent.futures.as_completed(futures):
+                res = fut.result()
+                if res:
+                    results.append(res)
+        return results
+
+    def _vectorize_single_document(self, object_key: str) -> Optional[Dict[str, str]]:
+        if not object_key:
+            return None
+        logger.info("Vectorising %s", object_key)
+        try:
+            obj = self.agent_nick.s3_client.get_object(
+                Bucket=self.settings.s3_bucket_name, Key=object_key
+            )
+            file_bytes = obj["Body"].read()
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error("Failed downloading %s: %s", object_key, exc)
+            return None
+        text = self._extract_text(file_bytes, object_key)
+        doc_type = self._classify_doc_type(text)
+        self._vectorize_document(text, None, doc_type, None, object_key)
+        return {
+            "object_key": object_key,
+            "id": object_key,
+            "doc_type": doc_type or "",
+            "status": "vectorized",
+        }

--- a/tests/test_data_extraction_agent.py
+++ b/tests/test_data_extraction_agent.py
@@ -170,5 +170,6 @@ def test_po_line_items_unit_mapping(monkeypatch):
     )
 
     insert_sql, params = executed[-1]
+    assert "proc.po_line_items_agent" in insert_sql
     assert "unit_of_measue" in insert_sql
     assert "pcs" in params

--- a/tests/test_document_vector_agent.py
+++ b/tests/test_document_vector_agent.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+from io import BytesIO
+
+from agents.document_vector_agent import DocumentVectorAgent
+
+
+def test_document_vector_agent_vectorizes(monkeypatch):
+    captured = {}
+    import numpy as np
+
+    nick = SimpleNamespace(
+        s3_client=SimpleNamespace(get_object=lambda Bucket, Key: {"Body": BytesIO(b"fake")}),
+        embedding_model=SimpleNamespace(encode=lambda chunks, **kwargs: [np.zeros(3) for _ in chunks]),
+        qdrant_client=SimpleNamespace(upsert=lambda **kwargs: captured.setdefault("vectorized", True)),
+        _initialize_qdrant_collection=lambda: None,
+        settings=SimpleNamespace(
+            s3_bucket_name="b",
+            s3_prefixes=[],
+            qdrant_collection_name="c",
+            extraction_model="m",
+        ),
+    )
+
+    agent = DocumentVectorAgent(nick)
+    monkeypatch.setattr(agent, "_extract_text", lambda b, k: "contract text")
+    monkeypatch.setattr(agent, "_classify_doc_type", lambda t: "Contract")
+
+    res = agent._vectorize_single_document("doc.pdf")
+
+    assert captured.get("vectorized")
+    assert res["id"] == "doc.pdf"
+    assert res["doc_type"] == "Contract"


### PR DESCRIPTION
## Summary
- Persist invoices and purchase orders to new `proc.*_agent` tables
- Introduce `DocumentVectorAgent` for embedding documents without structuring
- Cover vector agent and table mapping with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57dea09e88332a00e102ef67efa30