### PR TITLE
Refactor data extraction flow for vector-first processing

### DIFF
--- a/tests/test_data_extraction_numeric.py
+++ b/tests/test_data_extraction_numeric.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.data_extraction_agent import DataExtractionAgent
 


### PR DESCRIPTION
## Summary
- Vectorise raw documents before contextual analysis
- Sanitize vendor and supplier names to avoid `purchase` placeholders
- Update tests and path setup for new extraction flow

## Testing
- `pytest tests/test_data_extraction_numeric.py -vv`
- `pytest tests/test_data_extraction_agent.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b677f2e7ec8332840e2e1be206249a