### PR TITLE
Avoid vectorizing header data

### DIFF
--- a/tests/test_data_extraction_agent.py
+++ b/tests/test_data_extraction_agent.py
@@ -106,9 +106,8 @@ def test_vectorize_structured_data_creates_points(monkeypatch):
 
     agent._vectorize_structured_data(header, line_items, "Invoice", "1")
 
-    assert len(captured["points"]) == 2
-    assert captured["points"][0].payload["data_type"] == "header"
-    assert captured["points"][1].payload["data_type"] == "line_item"
+    assert len(captured["points"]) == 1
+    assert captured["points"][0].payload["data_type"] == "line_item"
 
 
 def test_contextual_field_normalisation():


### PR DESCRIPTION
## Summary
- skip embedding document header details in Qdrant for data extraction
- update structured data vectorization to store only line item content
- adjust tests to reflect new vectorization behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67bf67284833281e6e6584283524a