### PR TITLE
Streamlined run endpoint for process-based agent workflows

### DIFF
--- a/api/routers/run.py
+++ b/api/routers/run.py
@@ -1,18 +1,24 @@
 import os
-from typing import Any, Dict, List, Optional
-
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from orchestration.orchestrator import Orchestrator
+from utils.gpu import configure_gpu
 
 # Ensure GPU-related environment variables are set
 os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
 os.environ.setdefault("OLLAMA_USE_GPU", "1")
 os.environ.setdefault("OLLAMA_NUM_PARALLEL", "4")
 os.environ.setdefault("OMP_NUM_THREADS", "8")
+configure_gpu()
 
 router = APIRouter(tags=["Run"], prefix="")
+
+
+class RunRequest(BaseModel):
+    """Request schema for the ``/run`` endpoint."""
+
+    process_id: int
 
 
 def get_orchestrator(request: Request) -> Orchestrator:
@@ -24,84 +30,32 @@ def get_orchestrator(request: Request) -> Orchestrator:
     return orchestrator
 
 
-class AgentProperty(BaseModel):
-    """Configuration information for an agent.
-
-    The minimal data required to spin up an agent in the ProcWise
-    framework.  This mirrors the ``agent_property`` structure supplied by
-    the front end and is validated here before orchestration begins.
-    """
-
-    llm: str
-    memory: Optional[str] = ""
-    prompts: List[int] = Field(default_factory=list)
-    policies: List[int] = Field(default_factory=list)
-
-
-class AgentNode(BaseModel):
-    """Recursive description of an agent flow node."""
-
-    status: str
-    agent_type: str = Field(alias="agent_type")
-    agent_property: AgentProperty
-    onNormal: Optional[Any] = None
-    onFailure: Optional["AgentNode"] = None
-    onSuccess: Optional["AgentNode"] = None
-
-
-# Resolve forward references for self-referential model
-AgentNode.model_rebuild()
-
-
-class RunRequest(BaseModel):
-    """Request schema for the ``/run`` endpoint.
-
-    ``workflow`` is preserved for backwards compatibility with the
-    existing API.  The new ``agent_flow`` field enables clients to submit
-    a full agent orchestration graph which will be validated before
-    execution.
-    """
-
-    process_id: Optional[int] = None
-    workflow: Optional[str] = None
-    payload: Dict[str, Any] = {}
-    user_id: Optional[str] = None
-    agent_flow: Optional[AgentNode] = None
-
-
 @router.post("/run")
 def run_agents(
     req: RunRequest,
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ):
-    """Execute a workflow using the orchestrator."""
+    """Execute an agent flow fetched from the routing table."""
     prs = getattr(orchestrator.agent_nick, "process_routing_service", None)
-
-    if req.process_id is not None:
-        if not prs:
-            raise HTTPException(
-                status_code=503, detail="Process routing service is not available."
-            )
-        details = prs.get_process_details(req.process_id)
-        if details is None:
-            raise HTTPException(status_code=404, detail="Process not found")
-        prs.update_process_status(req.process_id, 1)
-        result = orchestrator.execute_agent_flow(details)
-        if isinstance(result, dict):
-            details["status"] = result.get("status", details.get("status"))
-            prs.update_process_details(req.process_id, details)
-        prs.update_process_status(
-            req.process_id, 2 if result.get("status") != "failed" else 3
-        )
-        return result
-
-    # When an agent flow is supplied we validate and execute it using the
-    # orchestrator.  Otherwise fall back to the legacy ``workflow`` based
-    # execution path.
-    if req.agent_flow is not None:
-        return orchestrator.execute_agent_flow(req.agent_flow.model_dump())
-    if req.workflow is None:
+    if not prs:
         raise HTTPException(
-            status_code=400, detail="Either process_id, workflow or agent_flow must be provided"
+            status_code=503, detail="Process routing service is not available."
         )
-    return orchestrator.execute_workflow(req.workflow, req.payload, user_id=req.user_id)
+
+    details = prs.get_process_details(req.process_id)
+    if details is None:
+        raise HTTPException(status_code=404, detail="Process not found")
+    if details.get("status") != "saved":
+        raise HTTPException(status_code=409, detail="Process not in saved status")
+
+    prs.update_process_status(req.process_id, 1)
+    result = orchestrator.execute_agent_flow(details)
+    if isinstance(result, dict):
+        details["status"] = (
+            "completed" if result.get("status") != "failed" else "failed"
+        )
+        prs.update_process_details(req.process_id, details)
+    prs.update_process_status(
+        req.process_id, 2 if result.get("status") != "failed" else 3
+    )
+    return result

--- a/tests/test_run_endpoint.py
+++ b/tests/test_run_endpoint.py
@@ -12,19 +12,14 @@ from api.routers.run import router as run_router
 
 
 class DummyPRS:
-    def __init__(self):
+    def __init__(self, status="saved"):
         self.status_updates = []
         self.details_updates = []
-
-    def log_process(self, **kwargs):
-        return 1
-
-    def log_action(self, **kwargs):
-        return kwargs.get("action_id", "a1")
+        self.status = status
 
     def get_process_details(self, process_id):
         return {
-            "status": "saved",
+            "status": self.status,
             "agent_type": "1",
             "agent_property": {"llm": "mistral", "prompts": [1], "policies": [2]},
         }
@@ -37,75 +32,27 @@ class DummyPRS:
 
 
 class DummyOrchestrator:
-    def __init__(self):
-        self.agent_nick = SimpleNamespace(process_routing_service=DummyPRS())
-
-    def execute_workflow(self, workflow_name, input_data, user_id=None):
-        return {
-            "status": "completed",
-            "workflow_id": "wf",
-            "result": {
-                "echo": input_data,
-                "workflow": workflow_name,
-                "user": user_id,
-            },
-        }
+    def __init__(self, prs=None):
+        self.agent_nick = SimpleNamespace(
+            process_routing_service=prs or DummyPRS()
+        )
 
     def execute_agent_flow(self, flow):
-        # Simple echo implementation for testing
         self.received_flow = flow
         return {"status": "validated", "plan": [flow]}
 
 
-def test_run_endpoint_executes_workflow():
+def create_client(prs=None):
     app = FastAPI()
     app.include_router(run_router)
-    orchestrator = DummyOrchestrator()
+    orchestrator = DummyOrchestrator(prs)
     app.state.orchestrator = orchestrator
     client = TestClient(app)
-
-    resp = client.post(
-        "/run", json={"workflow": "test", "payload": {"foo": "bar"}, "user_id": "u1"}
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["result"]["echo"]["foo"] == "bar"
-    assert data["result"]["workflow"] == "test"
-    assert data["result"]["user"] == "u1"
-
-
-def test_run_endpoint_validates_agent_flow():
-    app = FastAPI()
-    app.include_router(run_router)
-    orchestrator = DummyOrchestrator()
-    app.state.orchestrator = orchestrator
-    client = TestClient(app)
-
-    flow = {
-        "status": "saved",
-        "agent_type": "1",
-        "agent_property": {"llm": "mistral", "prompts": [1], "policies": [2]},
-        "onSuccess": {
-            "status": "saved",
-            "agent_type": "2",
-            "agent_property": {"llm": "phi", "prompts": [3], "policies": [4]},
-        },
-    }
-
-    resp = client.post("/run", json={"agent_flow": flow})
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["status"] == "validated"
-    assert data["plan"][0]["agent_type"] == "1"
+    return client, orchestrator
 
 
 def test_run_endpoint_process_id_executes_flow():
-    app = FastAPI()
-    app.include_router(run_router)
-    orchestrator = DummyOrchestrator()
-    app.state.orchestrator = orchestrator
-    client = TestClient(app)
-
+    client, orchestrator = create_client()
     resp = client.post("/run", json={"process_id": 5})
     assert resp.status_code == 200
     data = resp.json()
@@ -113,5 +60,12 @@ def test_run_endpoint_process_id_executes_flow():
 
     prs = orchestrator.agent_nick.process_routing_service
     assert prs.status_updates == [(5, 1), (5, 2)]
-    assert prs.details_updates[0]["status"] == "validated"
+    assert prs.details_updates[0]["status"] == "completed"
     assert orchestrator.received_flow["agent_type"] == "1"
+
+
+def test_run_endpoint_requires_saved_status():
+    prs = DummyPRS(status="completed")
+    client, _ = create_client(prs)
+    resp = client.post("/run", json={"process_id": 7})
+    assert resp.status_code == 409


### PR DESCRIPTION
## Summary
- Refactor `/run` endpoint to accept only `process_id`
- Fetch and validate routing details, enforcing `saved` status and marking completed
- Add GPU configuration and update tests for new endpoint behavior

## Testing
- `pytest tests/test_run_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c19352e08332aa84481475875b06