### PR TITLE
Handle JSON policy loading

### DIFF
--- a/tests/test_db_loading.py
+++ b/tests/test_db_loading.py
@@ -63,3 +63,17 @@ def test_load_policies_from_db():
     policies = orchestrator._load_policies()
     assert policies[2]["policyName"] == "Example"
 
+
+def test_invalid_prompt_json_is_ignored():
+    rows = [(99, "not-json")]
+    orchestrator = make_orchestrator(rows)
+    prompts = orchestrator._load_prompts()
+    assert 99 not in prompts
+
+
+def test_invalid_policy_json_is_ignored():
+    rows = [(99, "not-json")]
+    orchestrator = make_orchestrator(rows)
+    policies = orchestrator._load_policies()
+    assert 99 not in policies
+


### PR DESCRIPTION
## Summary
- ensure GPU is enabled by default in orchestrator
- safely parse JSON fields for prompts and policies
- add tests covering valid and invalid DB JSON data

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b702de50548332a5f5da9b44d9425f