### PR TITLE
Fix workflow status update in agent flow execution

### DIFF
--- a/tests/test_execute_agent_flow.py
+++ b/tests/test_execute_agent_flow.py
@@ -36,3 +36,51 @@ def test_execute_agent_flow_runs_and_updates_status():
     assert result["status"] == "completed"
     assert flow["status"] == "completed"
     assert agent.ran is True
+
+
+def test_execute_agent_flow_preserves_root_status_on_failure_chain():
+    """If the first agent fails, the overall flow should remain failed even
+    if a downstream agent succeeds."""
+
+    class ConfigurableAgent:
+        def __init__(self, status):
+            self.status = status
+
+        def execute(self, context):  # pragma: no cover - simple stub
+            return AgentOutput(status=self.status, data={})
+
+    fail_agent = ConfigurableAgent(AgentStatus.FAILED)
+    success_agent = ConfigurableAgent(AgentStatus.SUCCESS)
+
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"first": fail_agent, "second": success_agent},
+        policy_engine=SimpleNamespace(),
+        query_engine=SimpleNamespace(),
+        routing_engine=SimpleNamespace(routing_model=None),
+    )
+    orchestrator = Orchestrator(nick)
+
+    # Stub out lookups so our dummy agents are used
+    orchestrator._load_agent_definitions = lambda: {
+        "1": "FirstAgent",
+        "2": "SecondAgent",
+    }
+    orchestrator._load_prompts = lambda: {1: {}}
+    orchestrator._load_policies = lambda: {1: {}}
+
+    flow = {
+        "status": "saved",
+        "agent_type": "1",
+        "agent_property": {"llm": "m", "prompts": [1], "policies": [1]},
+        "onFailure": {
+            "status": "saved",
+            "agent_type": "2",
+            "agent_property": {"llm": "m", "prompts": [1], "policies": [1]},
+        },
+    }
+
+    orchestrator.execute_agent_flow(flow)
+
+    assert flow["status"] == "failed"
+    assert flow["onFailure"]["status"] == "completed"


### PR DESCRIPTION
## Summary
- ensure root agent status isn't overwritten by downstream agents during flow execution
- add regression test for failure->success chain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73c71204c8332a922915eb789b3fb