### PR TITLE
Handle invalid DB JSON and enforce process status codes

### DIFF
--- a/api/routers/agents.py
+++ b/api/routers/agents.py
@@ -112,7 +112,7 @@ def execute_agent(
             status="completed",
             action_id=action_id,
         )
-        prs.update_process_status(process_id, 2)
+        prs.update_process_status(process_id, 1)
         return result
     except Exception as exc:  # pragma: no cover - defensive
         prs.log_action(
@@ -122,5 +122,5 @@ def execute_agent(
             status="failed",
             action_id=action_id,
         )
-        prs.update_process_status(process_id, 0)
+        prs.update_process_status(process_id, -1)
         raise HTTPException(status_code=500, detail=str(exc))

--- a/api/routers/run.py
+++ b/api/routers/run.py
@@ -55,5 +55,5 @@ def run_agents(
         final = updated_flow.get("status")
     else:
         final = "failed"
-    prs.update_process_status(req.process_id, 2 if final != "failed" else 3)
+    prs.update_process_status(req.process_id, 1 if final != "failed" else -1)
     return {"status": final}

--- a/api/routers/workflows.py
+++ b/api/routers/workflows.py
@@ -203,7 +203,7 @@ def mine_opportunities(
             status="completed",
             action_id=action_id,
         )
-        prs.update_process_status(process_id, 2)
+        prs.update_process_status(process_id, 1)
         return result
     except Exception as exc:  # pragma: no cover - defensive
         prs.log_action(
@@ -213,7 +213,7 @@ def mine_opportunities(
             status="failed",
             action_id=action_id,
         )
-        prs.update_process_status(process_id, 0)
+        prs.update_process_status(process_id, -1)
         raise HTTPException(status_code=500, detail=str(exc))
 
 
@@ -262,7 +262,7 @@ async def extract_documents(
                 status="completed",
                 action_id=action_id,
             )
-            prs.update_process_status(process_id, 2)
+            prs.update_process_status(process_id, 1)
         except Exception as exc:  # pragma: no cover - network/runtime
             prs.log_action(
                 process_id=process_id,
@@ -271,7 +271,7 @@ async def extract_documents(
                 status="failed",
                 action_id=action_id,
             )
-            prs.update_process_status(process_id, 0)
+            prs.update_process_status(process_id, -1)
 
     asyncio.create_task(run_flow())
     return {"status": "process started", "process_id": process_id}

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -144,7 +144,7 @@ class Orchestrator:
                             logger.warning(
                                 "Invalid JSON for prompt %s: %s", pid, desc
                             )
-                            continue
+                            value = {"promptId": pid, "template": str(desc)}
                         prompts[int(pid)] = value
             if prompts:
                 return prompts
@@ -183,7 +183,7 @@ class Orchestrator:
                             logger.warning(
                                 "Invalid JSON for policy %s: %s", pid, desc
                             )
-                            continue
+                            value = {"policyId": pid, "description": str(desc)}
                         policies[int(pid)] = value
             if policies:
                 return policies

--- a/tests/test_db_loading.py
+++ b/tests/test_db_loading.py
@@ -64,16 +64,16 @@ def test_load_policies_from_db():
     assert policies[2]["policyName"] == "Example"
 
 
-def test_invalid_prompt_json_is_ignored():
+def test_invalid_prompt_json_is_wrapped():
     rows = [(99, "not-json")]
     orchestrator = make_orchestrator(rows)
     prompts = orchestrator._load_prompts()
-    assert 99 not in prompts
+    assert prompts[99]["template"] == "not-json"
 
 
-def test_invalid_policy_json_is_ignored():
+def test_invalid_policy_json_is_wrapped():
     rows = [(99, "not-json")]
     orchestrator = make_orchestrator(rows)
     policies = orchestrator._load_policies()
-    assert 99 not in policies
+    assert policies[99]["description"] == "not-json"
 

--- a/tests/test_run_endpoint.py
+++ b/tests/test_run_endpoint.py
@@ -63,7 +63,7 @@ def test_run_endpoint_process_id_executes_flow():
     assert data["status"] == "completed"
 
     prs = orchestrator.agent_nick.process_routing_service
-    assert prs.status_updates == [(5, 1), (5, 2)]
+    assert prs.status_updates == [(5, 1), (5, 1)]
     assert prs.details_updates[0]["status"] == "completed"
     assert orchestrator.received_flow["agent_type"] == "1"
 


### PR DESCRIPTION
## Summary
- add process status updater with validation
- wrap non-JSON prompts and policies into default structures
- standardize process status codes across endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7562523808332881815d12fd5b688