### PR TITLE
Expand run detail logging to match new schema

### DIFF
--- a/tests/test_agent_endpoints.py
+++ b/tests/test_agent_endpoints.py
@@ -23,6 +23,9 @@ class DummyPRS:
         self.logged.append(kwargs)
         return kwargs.get("action_id", "a1")
 
+    def log_run_detail(self, **kwargs):
+        return kwargs.get("run_id", "r1")
+
     def update_process_status(self, *args, **kwargs):
         pass
 

--- a/tests/test_run_endpoint.py
+++ b/tests/test_run_endpoint.py
@@ -30,6 +30,9 @@ class DummyPRS:
     def update_process_details(self, process_id, details, **kwargs):
         self.details_updates.append(details)
 
+    def log_run_detail(self, **kwargs):
+        return kwargs.get("run_id", "r1")
+
 
 class DummyOrchestrator:
     def __init__(self, prs=None):


### PR DESCRIPTION
## Summary
- log detailed run information including start/end times, status, and triggering user in `proc.routing_run_details`
- capture run timing and user context in `BaseAgent.execute`
- adjust tests for new run detail logging behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75bfbff54833292c4ebd3382524bd