### PR TITLE
Fix run logging parameters

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -91,7 +91,7 @@ class BaseAgent:
             user_name=self.agent_nick.settings.script_user,
         )
         if process_id is not None:
-            runid = self.agent_nick.process_routing_service.log_run_detail(
+            run_id = self.agent_nick.process_routing_service.log_run_detail(
                 process_id=process_id,
                 process_status=status,
                 process_details={"input": context.input_data, "output": result.data},
@@ -105,7 +105,7 @@ class BaseAgent:
                 action_desc=context.input_data,
                 process_output=result.data,
                 status="completed" if result.status == AgentStatus.SUCCESS else "failed",
-                runid=runid,
+                run_id=run_id,
             )
         return result
 

--- a/services/process_routing_service.py
+++ b/services/process_routing_service.py
@@ -289,7 +289,7 @@ class ProcessRoutingService:
                     cursor.execute(
                         """
                         INSERT INTO proc.routing (
-                            id-,
+                            run_id,
                             process_id,
                             process_details,
                             process_status,


### PR DESCRIPTION
## Summary
- use correct `run_id` parameter when logging agent actions
- fix SQL insert to store `run_id` in routing table

## Testing
- `CUDA_VISIBLE_DEVICES=0 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7b5dc581c8332abcdcf4bc02799aa