### PR TITLE
Handle new proc.routing schema for process runs

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -63,7 +63,11 @@ class BaseAgent:
     def __init__(self, agent_nick):
         self.agent_nick = agent_nick
         self.settings = agent_nick.settings
-        logger.info(f"Initialized agent: {self.__class__.__name__}")
+        # Ensure GPU environment variables are set for all agents
+        self.device = configure_gpu()
+        logger.info(
+            f"Initialized agent: {self.__class__.__name__} on device {self.device}"
+        )
 
     def run(self, *args, **kwargs):
         raise NotImplementedError("Each agent must implement its own 'run' method.")


### PR DESCRIPTION
## Summary
- record run metadata in proc.routing's raw_data and use integer status codes
- initialize agents with GPU configuration

## Testing
- `pytest tests/test_run_endpoint.py::test_run_endpoint_process_id_executes_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c9f40f74833297ffdff1ce94e1f0