### PR TITLE
Ensure process routing starts with status 0

### DIFF
--- a/api/routers/agents.py
+++ b/api/routers/agents.py
@@ -94,7 +94,6 @@ def execute_agent(
     process_id = prs.log_process(
         process_name=req.agent_type,
         process_details=req.payload,
-        process_status=1,
     )
     action_id = prs.log_action(
         process_id=process_id,

--- a/api/routers/run.py
+++ b/api/routers/run.py
@@ -50,8 +50,7 @@ def run_agents(
     if details.get("status") != "saved":
         raise HTTPException(status_code=409, detail="Process not in saved status")
 
-    # mark as started and run the long-running execution in background
-    prs.update_process_status(req.process_id, 1)
+    # Run the long-running execution in background
 
     def _background_run(details_obj, process_id):
         try:

--- a/api/routers/workflows.py
+++ b/api/routers/workflows.py
@@ -180,7 +180,6 @@ def mine_opportunities(
     process_id = prs.log_process(
         process_name="opportunity_mining",
         process_details=req.model_dump(),
-        process_status=1,
     )
     if process_id is None:
         raise HTTPException(status_code=500, detail="Failed to log process")

--- a/tests/test_run_endpoint.py
+++ b/tests/test_run_endpoint.py
@@ -70,11 +70,11 @@ def test_run_endpoint_process_id_executes_flow():
     import time
 
     for _ in range(50):
-        if prs.status_updates == [(5, 1), (5, 1)] and prs.details_updates:
+        if prs.status_updates == [(5, 1)] and prs.details_updates:
             break
         time.sleep(0.01)
 
-    assert prs.status_updates == [(5, 1), (5, 1)]
+    assert prs.status_updates == [(5, 1)]
     assert prs.details_updates[0]["status"] == "completed"
     assert orchestrator.received_flow["agent_type"] == "1"
 


### PR DESCRIPTION
## Summary
- Log processes with default status 0 in agent and workflow endpoints
- Avoid marking runs as successful before execution begins
- Update run endpoint tests for single status update

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdbec3c8cc8332b5e6117bea321513