### PR TITLE
Convert legacy agent details to flow

### DIFF
--- a/tests/test_process_routing_service.py
+++ b/tests/test_process_routing_service.py
@@ -52,3 +52,34 @@ def test_log_process_defaults_status_zero():
     assert pid == 42
     # process_status should default to 0 and not be None
     assert conn.cursor_obj.params[5] == 0
+
+
+def test_convert_agents_to_flow_builds_tree():
+    details = {
+        "status": "saved",
+        "agents": [
+            {
+                "agent": "1",
+                "status": "saved",
+                "agent_property": {"llm": "m", "prompts": [], "policies": []},
+                "dependencies": {"onSuccess": ["2"], "onFailure": ["3"]},
+            },
+            {
+                "agent": "2",
+                "status": "saved",
+                "agent_property": {"llm": "m", "prompts": [], "policies": []},
+                "dependencies": {},
+            },
+            {
+                "agent": "3",
+                "status": "saved",
+                "agent_property": {"llm": "m", "prompts": [], "policies": []},
+                "dependencies": {},
+            },
+        ],
+    }
+
+    flow = ProcessRoutingService.convert_agents_to_flow(details)
+    assert flow["agent_type"] == "1"
+    assert flow["onSuccess"]["agent_type"] == "2"
+    assert flow["onFailure"]["agent_type"] == "3"


### PR DESCRIPTION
## Summary
- translate legacy `agents` list into nested agent flow for orchestrator
- ensure `get_process_details` returns flow with required fields
- test conversion from list-based process details to flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf1912f0e083328995c6cd04654878