### PR TITLE
Fix agent mapping to use agent_type identifiers

### DIFF
--- a/tests/test_db_loading.py
+++ b/tests/test_db_loading.py
@@ -74,3 +74,11 @@ def test_load_policies_from_db():
     assert policies[2]["description"] == "Example policy"
     assert policies[2]["agents"][0]["agent_name"] == "AgentOne"
 
+
+def test_load_agent_definitions_from_db():
+    agent_rows = [(1, "AgentOne"), (2, "AgentTwo")]
+    orchestrator = make_orchestrator([], agent_rows)
+    defs = orchestrator._load_agent_definitions()
+    assert defs["1"] == "AgentOne"
+    assert defs["2"] == "AgentTwo"
+


### PR DESCRIPTION
## Summary
- Load agent definitions from `proc.agent` using `agent_type` identifiers, with a JSON fallback
- Add unit test for database-backed agent definition loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf291f5a7c8332b31f55bb3939a365