### PR TITLE
Fix agent linkage mappings in process routing

### DIFF
--- a/tests/test_db_loading.py
+++ b/tests/test_db_loading.py
@@ -58,8 +58,8 @@ def make_orchestrator(rows, agent_rows):
 
 
 def test_load_prompts_from_db():
-    prompt_rows = [(1, "hello", "{1}")]
-    agent_rows = [(1, "AgentOne")]
+    prompt_rows = [(1, "hello", "{agent_one}")]
+    agent_rows = [("agent_one", "AgentOne")]
     orchestrator = make_orchestrator(prompt_rows, agent_rows)
     prompts = orchestrator._load_prompts()
     assert prompts[1]["template"] == "hello"
@@ -67,8 +67,8 @@ def test_load_prompts_from_db():
 
 
 def test_load_policies_from_db():
-    policy_rows = [(2, "Example policy", "{1}")]
-    agent_rows = [(1, "AgentOne")]
+    policy_rows = [(2, "Example policy", "{agent_one}")]
+    agent_rows = [("agent_one", "AgentOne")]
     orchestrator = make_orchestrator(policy_rows, agent_rows)
     policies = orchestrator._load_policies()
     assert policies[2]["description"] == "Example policy"
@@ -76,9 +76,9 @@ def test_load_policies_from_db():
 
 
 def test_load_agent_definitions_from_db():
-    agent_rows = [(1, "AgentOne"), (2, "AgentTwo")]
+    agent_rows = [("a1", "AgentOne"), ("a2", "AgentTwo")]
     orchestrator = make_orchestrator([], agent_rows)
     defs = orchestrator._load_agent_definitions()
-    assert defs["1"] == "AgentOne"
-    assert defs["2"] == "AgentTwo"
+    assert defs["a1"] == "AgentOne"
+    assert defs["a2"] == "AgentTwo"
 


### PR DESCRIPTION
## Summary
- Resolve agent keys from new `*_linked_agents` columns
- Enrich stored process details with proper agent names, prompts, and policies
- Update tests for string-based agent linkage

## Testing
- `pytest tests/test_process_routing_service.py::test_get_process_details_enriches_agent_data tests/test_db_loading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf2d3f73e8833299a45707e6c9232d