### PR TITLE
Load agent definitions from bundled file

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -113,24 +113,12 @@ class Orchestrator:
     def _load_agent_definitions(self) -> Dict[str, str]:
         """Return mapping of ``agent_type`` identifiers to agent class names.
 
-        The primary source of truth is the ``proc.agent`` table where
-        ``agent_type`` uniquely identifies an agent implementation.  When a
-        database connection isn't available the method falls back to the
-        bundled ``agent_definitions.json`` file which mirrors the same
-        structure.
+        ``proc.agent`` is no longer consulted; instead the bundled
+        ``agent_definitions.json`` file acts as the sole source of truth for
+        agent metadata.  Each entry provides slug-based identifiers (e.g.
+        ``supplier_ranking`` and ``admin_supplier_ranking``) along with the
+        legacy numeric ``agentId`` for backward compatibility.
         """
-
-        try:
-            with self.agent_nick.get_db_connection() as conn:
-                with conn.cursor() as cursor:
-                    cursor.execute("SELECT agent_type, agent_name FROM proc.agent")
-                    rows = cursor.fetchall()
-                if rows:
-                    return {str(row[0]): row[1] for row in rows}
-        except Exception:  # pragma: no cover - defensive fall back
-            logger.exception(
-                "Failed to load agent definitions from DB, falling back to file"
-            )
 
         path = Path(__file__).resolve().parents[1] / "agent_definitions.json"
         with path.open() as f:

--- a/tests/test_process_routing_service.py
+++ b/tests/test_process_routing_service.py
@@ -87,9 +87,8 @@ def test_convert_agents_to_flow_builds_tree():
 
 
 class FetchCursor:
-    def __init__(self, proc_details, agent_rows, prompt_rows, policy_rows):
+    def __init__(self, proc_details, prompt_rows, policy_rows):
         self.proc_details = proc_details
-        self.agent_rows = agent_rows
         self.prompt_rows = prompt_rows
         self.policy_rows = policy_rows
         self.query = ""
@@ -103,8 +102,6 @@ class FetchCursor:
         return None
 
     def fetchall(self):
-        if "FROM proc.agent" in self.query:
-            return self.agent_rows
         if "FROM proc.prompt" in self.query:
             return self.prompt_rows
         if "FROM proc.policy" in self.query:
@@ -119,16 +116,13 @@ class FetchCursor:
 
 
 class FetchConn:
-    def __init__(self, proc_details, agent_rows, prompt_rows, policy_rows):
+    def __init__(self, proc_details, prompt_rows, policy_rows):
         self.proc_details = proc_details
-        self.agent_rows = agent_rows
         self.prompt_rows = prompt_rows
         self.policy_rows = policy_rows
 
     def cursor(self):
-        return FetchCursor(
-            self.proc_details, self.agent_rows, self.prompt_rows, self.policy_rows
-        )
+        return FetchCursor(self.proc_details, self.prompt_rows, self.policy_rows)
 
     def __enter__(self):
         return self
@@ -145,7 +139,6 @@ def test_get_process_details_enriches_agent_data():
     }
     conn = FetchConn(
         proc_details,
-        [("admin_supplier_ranking", "SupplierRankingAgent")],
         [(1, "{admin_supplier_ranking}")],
         [(2, "{admin_supplier_ranking}")],
     )


### PR DESCRIPTION
## Summary
- stop querying `proc.agent` table; load agent metadata from bundled `agent_definitions.json`
- use file-based definitions when enriching prompt/policy links
- adjust tests to exercise file-only workflow

## Testing
- `CUDA_VISIBLE_DEVICES=0 OLLAMA_USE_GPU=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfd2392fc48332aefe323f91a2811a