### PR TITLE
Improve error logging with stack traces

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -83,7 +83,7 @@ class BaseAgent:
         try:
             result = self.run(context)
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error("%s execution failed: %s", self.__class__.__name__, exc)
+            logger.exception("%s execution failed", self.__class__.__name__)
             result = AgentOutput(status=AgentStatus.FAILED, data={}, error=str(exc))
         end_ts = datetime.utcnow()
 
@@ -152,7 +152,7 @@ class BaseAgent:
                 **kwargs,
             )
         except Exception as exc:  # pragma: no cover - network / runtime issues
-            logger.error("Ollama call failed: %s", exc)
+            logger.exception("Ollama call failed")
             return {"response": "", "error": str(exc)}
 
 class AgentNick:

--- a/agents/supplier_ranking_agent.py
+++ b/agents/supplier_ranking_agent.py
@@ -43,7 +43,7 @@ class SupplierRankingAgent(BaseAgent):
             try:
                 df = pd.DataFrame(supplier_data)
             except Exception as e:
-                logger.error(f"Invalid supplier_data format: {e}")
+                logger.exception("Invalid supplier_data format")
                 return AgentOutput(
                     status=AgentStatus.FAILED,
                     data={},
@@ -178,5 +178,5 @@ class SupplierRankingAgent(BaseAgent):
             resp = self.call_ollama(prompt, model=self.settings.extraction_model)
             return resp.get('response', '').strip()
         except Exception as e:
-            logger.error(f"Justification generation failed: {e}")
+            logger.exception("Justification generation failed")
             return "Justification generation failed."

--- a/services/process_routing_service.py
+++ b/services/process_routing_service.py
@@ -243,8 +243,8 @@ class ProcessRoutingService:
                         "Logged process %s with id %s", process_name, process_id
                     )
                     return process_id
-        except Exception as exc:
-            logger.error("Failed to log process %s: %s", process_name, exc)
+        except Exception:
+            logger.exception("Failed to log process %s", process_name)
             return None
 
     def get_process_details(self, process_id: int) -> Optional[Dict[str, Any]]:
@@ -267,8 +267,8 @@ class ProcessRoutingService:
                         agent_defs, prompt_map, policy_map = self._load_agent_links()
                         self._enrich_node(details, agent_defs, prompt_map, policy_map)
                         return details
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to fetch process %s: %s", process_id, exc)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("Failed to fetch process %s", process_id)
         return None
 
     def update_process_details(
@@ -299,9 +299,9 @@ class ProcessRoutingService:
                     logger.info(
                         "Updated process %s details", process_id
                     )
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error(
-                "Failed to update details for process %s: %s", process_id, exc
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "Failed to update details for process %s", process_id
             )
 
     def update_process_status(self, process_id: int, status: int, modified_by: Optional[str] = None) -> None:
@@ -333,9 +333,9 @@ class ProcessRoutingService:
                     logger.info(
                         "Updated process %s to status %s", process_id, status
                     )
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error(
-                "Failed to update status for process %s: %s", process_id, exc
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "Failed to update status for process %s", process_id
             )
 
 
@@ -402,9 +402,9 @@ class ProcessRoutingService:
                         status,
                     )
                     return action_id
-        except Exception as exc:
-            logger.error(
-                "Failed to log action for process %s: %s", process_id, exc
+        except Exception:
+            logger.exception(
+                "Failed to log action for process %s", process_id
             )
             return None
 
@@ -524,8 +524,8 @@ class ProcessRoutingService:
                         status_int,
                     )
                     return run_id
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error(
-                "Failed to log run for process %s: %s", process_id, exc
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "Failed to log run for process %s", process_id
             )
             return None


### PR DESCRIPTION
## Summary
- surface full tracebacks when process logging fails
- surface agent execution errors with stack traces
- show detailed supplier ranking failures

## Testing
- `pytest -q` *(fails: KeyError: 'admin_supplier_ranking', AssertionError: assert 'admin_supplier_ranking_123' == 'SupplierRankingAgent')*

------
https://chatgpt.com/codex/tasks/task_e_68bfd7e7e1308332bce5b6313339db2a