### PR TITLE
Allow structured answers in chat history API

### DIFF
--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -2,14 +2,17 @@
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 import ollama
-from typing import List
+from typing import Any, Dict, List, Union
 from pydantic import BaseModel
 from services.model_selector import RAGPipeline
+from utils.gpu import configure_gpu
+
+configure_gpu()
 
 
 class ChatMessage(BaseModel):
     query: str
-    answer: str
+    answer: Union[str, Dict[str, Any], List[Any]]
 
 router = APIRouter(prefix="/system", tags=["System Information & History"])
 


### PR DESCRIPTION
## Summary
- Support non-string chat answers in system history endpoint
- Preserve structured answers when loading chat history from S3
- Ensure GPU settings are applied in system router

## Testing
- `pytest` *(fails: KeyError 'admin_supplier_ranking'; AssertionError in process routing service)*

------
https://chatgpt.com/codex/tasks/task_e_68c04108f3b4833286c96762cee4d5bf