### PR TITLE
Enhance /run workflow handling and process routing

### DIFF
--- a/engines/query_engine.py
+++ b/engines/query_engine.py
@@ -34,3 +34,15 @@ class QueryEngine(BaseEngine):
                 FROM proc.supplier;"""
         with self.agent_nick.get_db_connection() as conn:
             return pd.read_sql(sql, conn)
+
+    def fetch_invoice_data(self, intent: dict | None = None) -> pd.DataFrame:
+        """Return invoice headers from ``proc.invoice_agent``."""
+        sql = "SELECT * FROM proc.invoice_agent;"
+        with self.agent_nick.get_db_connection() as conn:
+            return pd.read_sql(sql, conn)
+
+    def fetch_purchase_order_data(self, intent: dict | None = None) -> pd.DataFrame:
+        """Return purchase order headers from ``proc.purchase_order_agent``."""
+        sql = "SELECT * FROM proc.purchase_order_agent;"
+        with self.agent_nick.get_db_connection() as conn:
+            return pd.read_sql(sql, conn)

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -115,9 +115,9 @@ class Orchestrator:
 
         ``proc.agent`` is no longer consulted; instead the bundled
         ``agent_definitions.json`` file acts as the sole source of truth for
-        agent metadata.  Each entry provides slug-based identifiers (e.g.
-        ``supplier_ranking`` and ``admin_supplier_ranking``) along with the
-        legacy numeric ``agentId`` for backward compatibility.
+        agent metadata. Each entry provides slug-based identifiers (e.g.
+        ``supplier_ranking``) along with the legacy numeric ``agentId`` for
+        backward compatibility.
         """
 
         path = Path(__file__).resolve().parents[1] / "agent_definitions.json"

--- a/tests/test_db_loading.py
+++ b/tests/test_db_loading.py
@@ -73,5 +73,5 @@ def test_load_agent_definitions_from_file():
     orchestrator = make_orchestrator([])
     defs = orchestrator._load_agent_definitions()
     assert defs["supplier_ranking"] == "SupplierRankingAgent"
-    assert defs["admin_supplier_ranking"] == "SupplierRankingAgent"
+    assert "admin_supplier_ranking" not in defs
 

--- a/tests/test_execute_agent_flow.py
+++ b/tests/test_execute_agent_flow.py
@@ -102,14 +102,14 @@ def test_execute_agent_flow_ignores_agent_id_suffix():
     )
     orchestrator = Orchestrator(nick)
     orchestrator._load_agent_definitions = lambda: {
-        "admin_supplier_ranking": "SupplierRankingAgent"
+        "supplier_ranking": "SupplierRankingAgent"
     }
     orchestrator._load_prompts = lambda: {1: {}}
     orchestrator._load_policies = lambda: {1: {}}
 
     flow = {
         "status": "saved",
-        "agent_type": "admin_supplier_ranking_000055_1757337997564",
+        "agent_type": "supplier_ranking_000055_1757337997564",
         "agent_property": {"llm": "m", "prompts": [1], "policies": [1]},
     }
 

--- a/tests/test_process_details_structure.py
+++ b/tests/test_process_details_structure.py
@@ -13,6 +13,7 @@ def test_normalize_process_details_scenario1():
     details = ProcessRoutingService.normalize_process_details(raw)
 
     assert details["status"] == ""
+    assert details["process_status"] == 0
     assert len(details["agents"]) == 3
     assert details["agents"][0]["dependencies"] == {
         "onSuccess": [],
@@ -39,6 +40,7 @@ def test_normalize_process_details_scenario2():
     details = ProcessRoutingService.normalize_process_details(raw)
 
     assert details["status"] == "saved"
+    assert details["process_status"] == 0
     assert len(details["agents"]) == 4
     assert details["agents"][2]["dependencies"]["onSuccess"] == ["A1"]
     assert details["agents"][3]["dependencies"]["onFailure"] == ["A1", "A2"]

--- a/tests/test_process_routing_service.py
+++ b/tests/test_process_routing_service.py
@@ -134,13 +134,13 @@ class FetchConn:
 def test_get_process_details_enriches_agent_data():
     proc_details = {
         "status": "saved",
-        "agent_type": "admin_supplier_ranking_123",
+        "agent_type": "supplier_ranking_123",
         "agent_property": {"llm": None, "prompts": [], "policies": []},
     }
     conn = FetchConn(
         proc_details,
-        [(1, "{admin_supplier_ranking}")],
-        [(2, "{admin_supplier_ranking}")],
+        [(1, "{supplier_ranking}")],
+        [(2, "{supplier_ranking}")],
     )
     agent = SimpleNamespace(
         get_db_connection=lambda: conn,
@@ -151,3 +151,4 @@ def test_get_process_details_enriches_agent_data():
     assert details["agent_type"] == "SupplierRankingAgent"
     assert details["agent_property"]["prompts"] == [1]
     assert details["agent_property"]["policies"] == [2]
+    assert details["process_status"] == 0


### PR DESCRIPTION
## Summary
- Track process execution state via `process_status` and update routing details before and after `/run` execution.
- Normalize and enrich routing metadata using canonical agent names and DB-linked prompts/policies.
- Add invoice and purchase order data accessors to `QueryEngine` for downstream agents.
- Support agent lookups strictly by canonical names in the orchestrator and routing services.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c05dde7c748332a11708988274be99