### PR TITLE
Normalize dynamic agent identifiers

### DIFF
--- a/tests/test_execute_agent_flow.py
+++ b/tests/test_execute_agent_flow.py
@@ -117,3 +117,31 @@ def test_execute_agent_flow_ignores_agent_id_suffix():
 
     assert flow["status"] == "completed"
     assert agent.ran is True
+
+
+def test_execute_agent_flow_handles_prefixed_agent_names():
+    agent = DummyAgent()
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"quote_evaluation": agent},
+        policy_engine=SimpleNamespace(),
+        query_engine=SimpleNamespace(),
+        routing_engine=SimpleNamespace(routing_model=None),
+    )
+    orchestrator = Orchestrator(nick)
+    orchestrator._load_agent_definitions = lambda: {
+        "quote_evaluation": "QuoteEvaluationAgent"
+    }
+    orchestrator._load_prompts = lambda: {1: {}}
+    orchestrator._load_policies = lambda: {1: {}}
+
+    flow = {
+        "status": "saved",
+        "agent_type": "admin_quote_agent_000067_1757404210002",
+        "agent_property": {"llm": "m", "prompts": [1], "policies": [1]},
+    }
+
+    orchestrator.execute_agent_flow(flow)
+
+    assert flow["status"] == "completed"
+    assert agent.ran is True

--- a/tests/test_process_routing_service.py
+++ b/tests/test_process_routing_service.py
@@ -152,3 +152,24 @@ def test_get_process_details_enriches_agent_data():
     assert details["agent_property"]["prompts"] == [1]
     assert details["agent_property"]["policies"] == [2]
     assert details["process_status"] == 0
+
+
+def test_get_process_details_handles_prefixed_agent_names():
+    proc_details = {
+        "status": "saved",
+        "agent_type": "admin_quote_agent_000067_1757404210002",
+        "agent_property": {"llm": None, "prompts": [], "policies": []},
+    }
+    conn = FetchConn(proc_details, [], [])
+    agent = SimpleNamespace(
+        get_db_connection=lambda: conn,
+        settings=SimpleNamespace(script_user="tester"),
+    )
+    prs = ProcessRoutingService(agent)
+    prs._load_agent_links = lambda: (
+        {"quote_evaluation": "QuoteEvaluationAgent"},
+        {},
+        {},
+    )
+    details = prs.get_process_details(1)
+    assert details["agent_type"] == "QuoteEvaluationAgent"


### PR DESCRIPTION
## Summary
- Canonicalize agent identifiers with helper that strips runtime prefixes/suffixes and matches definitions
- Resolve agent types in process routing service and orchestrator using agent_definitions.json
- Add regression tests covering prefixed agent names

## Testing
- `CUDA_VISIBLE_DEVICES=0 OLLAMA_USE_GPU=1 OLLAMA_NUM_PARALLEL=4 OMP_NUM_THREADS=8 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c067aaa0b48332912afc995b06803a