### PR TITLE
Handle class-name agent types in orchestrator

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -146,15 +146,27 @@ class Orchestrator:
 
         if not raw_key:
             return None
+
+        # Strip runtime suffixes/prefixes and normalise for comparison
         key = re.sub(r"_[0-9]+(?:_[0-9]+)*$", "", raw_key)
         key = re.sub(r"^(?:admin|user|service)_", "", key)
         key = re.sub(r"_agent$", "", key)
-        if key in agent_defs:
-            return key
-        if raw_key in agent_defs:
-            return raw_key
+
+        key_lower = key.lower()
+        if key_lower in agent_defs:
+            return key_lower
+
+        raw_lower = raw_key.lower()
+        if raw_lower in agent_defs:
+            return raw_lower
+
+        # Attempt to resolve CamelCase class names into registry slugs
+        resolved = Orchestrator._resolve_agent_name(raw_key)
+        if resolved in agent_defs:
+            return resolved
+
         for slug in agent_defs:
-            if slug in key or key in slug:
+            if slug in key_lower or key_lower in slug:
                 return slug
         return None
 

--- a/tests/test_execute_agent_flow.py
+++ b/tests/test_execute_agent_flow.py
@@ -145,3 +145,31 @@ def test_execute_agent_flow_handles_prefixed_agent_names():
 
     assert flow["status"] == "completed"
     assert agent.ran is True
+
+
+def test_execute_agent_flow_accepts_class_name():
+    agent = DummyAgent()
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"quote_evaluation": agent},
+        policy_engine=SimpleNamespace(),
+        query_engine=SimpleNamespace(),
+        routing_engine=SimpleNamespace(routing_model=None),
+    )
+    orchestrator = Orchestrator(nick)
+    orchestrator._load_agent_definitions = lambda: {
+        "quote_evaluation": "QuoteEvaluationAgent"
+    }
+    orchestrator._load_prompts = lambda: {1: {}}
+    orchestrator._load_policies = lambda: {1: {}}
+
+    flow = {
+        "status": "saved",
+        "agent_type": "QuoteEvaluationAgent",
+        "agent_property": {"llm": "m", "prompts": [1], "policies": [1]},
+    }
+
+    orchestrator.execute_agent_flow(flow)
+
+    assert flow["status"] == "completed"
+    assert agent.ran is True


### PR DESCRIPTION
## Summary
- normalize agent identifiers so CamelCase class names map to registry entries
- ensure orchestrator keeps GPU-friendly defaults
- add regression test for QuoteEvaluationAgent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c074435a50833289f1f24e17595a56