### PR TITLE
Improve generic workflow execution and GPU setup

### DIFF
--- a/agents/quote_evaluation_agent.py
+++ b/agents/quote_evaluation_agent.py
@@ -34,10 +34,11 @@ class QuoteEvaluationAgent(BaseAgent):
             )
 
             if not quotes:
+                # Absence of quotes should not be treated as a hard failure:
+                # downstream agents may still proceed with an empty result set.
                 return AgentOutput(
-                    status=AgentStatus.FAILED,
-                    data={"message": "No quotes found"},
-                    error="No quotes to evaluate",
+                    status=AgentStatus.SUCCESS,
+                    data={"quotes": [], "message": "No quotes found"},
                 )
 
             simplified: List[Dict] = []

--- a/tests/test_agent_resolution.py
+++ b/tests/test_agent_resolution.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from orchestration.orchestrator import Orchestrator
+
+
+def make_orchestrator():
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={},
+        policy_engine=SimpleNamespace(),
+        query_engine=SimpleNamespace(),
+        routing_engine=SimpleNamespace(routing_model={}),
+    )
+    return Orchestrator(nick)
+
+
+def test_canonical_key_handles_decorated_names():
+    orch = make_orchestrator()
+    defs = orch._load_agent_definitions()
+
+    slug1 = orch._canonical_key("SupplierRankingAgent", defs)
+    slug2 = orch._canonical_key("user_supplier_ranking_agent_1", defs)
+
+    assert slug1 == "supplier_ranking"
+    assert slug2 == "supplier_ranking"
+
+
+def test_get_agent_details_parses_array_string():
+    orch = make_orchestrator()
+    details = orch._get_agent_details("{supplier_ranking,quote_evaluation}")
+    types = {d["agent_type"] for d in details}
+    assert {"supplier_ranking", "quote_evaluation"} <= types

--- a/tests/test_data_extraction_agent.py
+++ b/tests/test_data_extraction_agent.py
@@ -105,9 +105,11 @@ def test_vectorize_structured_data_creates_points(monkeypatch):
     line_items = [{"item_id": "A1", "description": "Widget"}]
 
     agent._vectorize_structured_data(header, line_items, "Invoice", "1")
-
-    assert len(captured["points"]) == 1
-    assert captured["points"][0].payload["data_type"] == "line_item"
+    types = {p.payload["data_type"] for p in captured["points"]}
+    assert types == {"header", "line_item"}
+    # ensure points are associated with the same record id
+    for p in captured["points"]:
+        assert p.payload["record_id"] == "1"
 
 
 def test_contextual_field_normalisation():

--- a/tests/test_execute_agent_flow.py
+++ b/tests/test_execute_agent_flow.py
@@ -8,6 +8,46 @@ from orchestration.orchestrator import Orchestrator
 from agents.base_agent import AgentOutput, AgentStatus
 
 
+class EchoAgent:
+    def execute(self, context):
+        return AgentOutput(status=AgentStatus.SUCCESS, data={"result": context.input_data.get("number")})
+
+
+def test_json_flow_executes_steps_with_context_mapping():
+    agent = EchoAgent()
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"echo": agent},
+        policy_engine=SimpleNamespace(),
+        query_engine=SimpleNamespace(),
+        routing_engine=SimpleNamespace(routing_model=None),
+    )
+    orchestrator = Orchestrator(nick)
+
+    flow = {
+        "entrypoint": "step1",
+        "steps": {
+            "step1": {
+                "agent": "echo",
+                "input": {"number": "{{ payload.value }}"},
+                "outputs": {"calc": "$.result"},
+                "next": "step2",
+            },
+            "step2": {
+                "agent": "echo",
+                "condition": "{{ ctx.calc == 1 }}",
+                "input": {"number": "{{ ctx.calc + 1 }}"},
+                "outputs": {"final": "$.result"},
+            },
+        },
+    }
+
+    result = orchestrator.execute_agent_flow(flow, {"value": 1})
+    assert result["status"] == "completed"
+    assert result["ctx"]["calc"] == 1
+    assert result["ctx"]["final"] == 2
+
+
 class DummyAgent:
     def __init__(self):
         self.ran = False
@@ -145,6 +185,59 @@ def test_execute_agent_flow_handles_prefixed_agent_names():
 
     assert flow["status"] == "completed"
     assert agent.ran is True
+
+
+def test_execute_agent_flow_passes_fields_to_children():
+    class ParentAgent:
+        def execute(self, context):
+            return AgentOutput(
+                status=AgentStatus.SUCCESS,
+                data={},
+                pass_fields={"shared": "value"},
+            )
+
+    class ChildAgent:
+        def __init__(self):
+            self.seen = None
+
+        def execute(self, context):  # pragma: no cover - simple stub
+            self.seen = context.input_data.get("shared")
+            return AgentOutput(status=AgentStatus.SUCCESS, data={})
+
+    parent = ParentAgent()
+    child = ChildAgent()
+
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"parent": parent, "child": child},
+        policy_engine=SimpleNamespace(),
+        query_engine=SimpleNamespace(),
+        routing_engine=SimpleNamespace(routing_model=None),
+    )
+
+    orchestrator = Orchestrator(nick)
+    orchestrator._load_agent_definitions = lambda: {
+        "parent": "ParentAgent",
+        "child": "ChildAgent",
+    }
+    orchestrator._load_prompts = lambda: {}
+    orchestrator._load_policies = lambda: {}
+
+    flow = {
+        "status": "saved",
+        "agent_type": "parent",
+        "agent_property": {},
+        "onSuccess": {
+            "status": "saved",
+            "agent_type": "child",
+            "agent_property": {},
+        },
+    }
+
+    orchestrator.execute_agent_flow(flow)
+
+    assert flow["status"] == "completed"
+    assert child.seen == "value"
 
 
 def test_execute_agent_flow_accepts_class_name():

--- a/tests/test_generic_workflow_context.py
+++ b/tests/test_generic_workflow_context.py
@@ -1,0 +1,47 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from orchestration.orchestrator import Orchestrator
+from agents.base_agent import AgentContext, AgentOutput, AgentStatus
+
+
+class RecordingAgent:
+    def __init__(self, next_agents=None, pass_fields=None):
+        self.calls = []
+        self.received = []
+        self.next_agents = next_agents or []
+        self.pass_fields = pass_fields or {}
+
+    def execute(self, context):  # pragma: no cover - simple behaviour
+        self.calls.append(context.agent_id)
+        self.received.append(dict(context.input_data))
+        return AgentOutput(
+            status=AgentStatus.SUCCESS,
+            data={},
+            next_agents=self.next_agents,
+            pass_fields=self.pass_fields,
+        )
+
+
+def test_generic_workflow_uses_child_context_and_pass_fields():
+    agent1 = RecordingAgent(next_agents=["second"], pass_fields={"foo": "bar"})
+    agent2 = RecordingAgent()
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"start": agent1, "second": agent2},
+        policy_engine=SimpleNamespace(),
+        query_engine=SimpleNamespace(),
+        routing_engine=SimpleNamespace(routing_model={}),
+    )
+    orchestrator = Orchestrator(nick)
+    context = AgentContext(
+        workflow_id="wf", agent_id="start", user_id="tester", input_data={}
+    )
+    orchestrator._execute_generic_workflow("start", context)
+
+    assert agent1.calls == ["start"]
+    assert agent2.calls == ["second"]
+    assert agent2.received[0].get("foo") == "bar"

--- a/tests/test_quote_evaluation_agent.py
+++ b/tests/test_quote_evaluation_agent.py
@@ -71,6 +71,22 @@ def test_quote_evaluation_agent_run(monkeypatch):
     assert output.data["quotes"][0]["total_spend"] == 1000
 
 
+def test_quote_evaluation_handles_no_quotes(monkeypatch):
+    """Agent should succeed gracefully when no quotes are found."""
+    nick = DummyNick()
+    agent = QuoteEvaluationAgent(nick)
+    monkeypatch.setattr(agent, "_fetch_quotes", lambda *_, **__: [])
+    context = AgentContext(
+        workflow_id="wf_empty",
+        agent_id="quote_evaluation",
+        user_id="u1",
+        input_data={},
+    )
+    output = agent.run(context)
+    assert output.status == AgentStatus.SUCCESS
+    assert output.data["quotes"] == []
+
+
 class DummyOrchestrator:
     def __init__(self, agent):
         self.agent = agent


### PR DESCRIPTION
## Summary
- initialise GPU configuration when orchestrator starts
- execute generic workflows with child contexts and pass field propagation
- cache agent definition loading to avoid repeated file I/O and add tests for agent name resolution
- embed procurement document headers alongside line items for richer RAG retrieval
- add regression tests for workflow context handling and structured data vectorization
- propagate pass fields in dynamic flows and allow optional prompts/policies
- test dynamic flow pass field chaining
- add JSON-defined flow executor with templating, context mapping and payload support
- handle empty quote evaluation results without failing the workflow

## Testing
- `pytest tests/test_execute_agent_flow.py::test_json_flow_executes_steps_with_context_mapping -q`
- `pytest tests/test_quote_evaluation_agent.py::test_quote_evaluation_handles_no_quotes -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c08c650298833290ad9f382376fe23