### PR TITLE
Preserve workflow agent statuses and fix flow status logic

### DIFF
--- a/api/routers/run.py
+++ b/api/routers/run.py
@@ -53,10 +53,9 @@ def run_agents(
     if details is None:
         raise HTTPException(status_code=404, detail="Process not found")
 
-    # Mark the process as started (process_status=0) before kicking off the
-    # background execution so that callers can poll for progress in
-    # real-time.
-    details["process_status"] = 0
+    # Mark the process as started before kicking off the background execution
+    # so that callers can poll for progress in real-time.
+    details["status"] = "started"
     try:
         prs.update_process_details(req.process_id, details)
     except Exception:
@@ -75,7 +74,6 @@ def run_agents(
             logger.debug("Execution result for process %s: %s", process_id, result)
             if isinstance(result, dict):
                 final = result.get("status")
-                result["process_status"] = 1 if final != "failed" else -1
                 try:
                     prs.update_process_details(process_id, result)
                 except Exception:

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -424,8 +424,6 @@ class Orchestrator:
                 except Exception as exc:  # pragma: no cover - execution error
                     logger.exception("Agent %s execution failed", agent_key)
                     run_ctx["errors"][step_name] = str(exc)
-            success = False
-
             if not success:
                 flow_status = "failed"
                 if on_error == "fail":

--- a/tests/test_process_details_structure.py
+++ b/tests/test_process_details_structure.py
@@ -13,7 +13,6 @@ def test_normalize_process_details_scenario1():
     details = ProcessRoutingService.normalize_process_details(raw)
 
     assert details["status"] == ""
-    assert details["process_status"] == 0
     assert len(details["agents"]) == 3
     assert details["agents"][0]["dependencies"] == {
         "onSuccess": [],
@@ -40,7 +39,6 @@ def test_normalize_process_details_scenario2():
     details = ProcessRoutingService.normalize_process_details(raw)
 
     assert details["status"] == "saved"
-    assert details["process_status"] == 0
     assert len(details["agents"]) == 4
     assert details["agents"][2]["dependencies"]["onSuccess"] == ["A1"]
     assert details["agents"][3]["dependencies"]["onFailure"] == ["A1", "A2"]

--- a/tests/test_process_routing_service.py
+++ b/tests/test_process_routing_service.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+from datetime import datetime
 from types import SimpleNamespace
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -151,7 +152,6 @@ def test_get_process_details_enriches_agent_data():
     assert details["agent_type"] == "SupplierRankingAgent"
     assert details["agent_property"]["prompts"] == [1]
     assert details["agent_property"]["policies"] == [2]
-    assert details["process_status"] == 0
 
 
 def test_get_process_details_handles_prefixed_agent_names():
@@ -173,3 +173,78 @@ def test_get_process_details_handles_prefixed_agent_names():
     )
     details = prs.get_process_details(1)
     assert details["agent_type"] == "QuoteEvaluationAgent"
+
+
+def test_update_agent_status_preserves_structure():
+    initial = {
+        "status": "",
+        "agents": [
+            {"agent": "A1", "dependencies": {"onSuccess": [], "onFailure": [], "onCompletion": []}, "status": "saved", "agent_ref_id": "1"},
+            {"agent": "A2", "dependencies": {"onSuccess": ["A1"], "onFailure": [], "onCompletion": []}, "status": "saved", "agent_ref_id": "2"},
+            {"agent": "A3", "dependencies": {"onSuccess": [], "onFailure": ["A1"], "onCompletion": []}, "status": "saved", "agent_ref_id": "3"},
+        ],
+    }
+    conn = DummyConn()
+    agent = SimpleNamespace(
+        get_db_connection=lambda: conn,
+        settings=SimpleNamespace(script_user="tester"),
+    )
+    prs = ProcessRoutingService(agent)
+    prs.get_process_details = lambda pid: initial
+    prs.update_agent_status(1, "A2", "running")
+    updated = json.loads(conn.cursor_obj.params[0])
+    assert updated["agents"][1]["status"] == "running"
+    assert updated["agents"][0]["status"] == "saved"
+    assert updated["agents"][2]["dependencies"]["onFailure"] == ["A1"]
+
+
+def test_update_agent_status_preserves_structure_scenario2():
+    initial = {
+        "status": "",
+        "agents": [
+            {"agent": "A1", "dependencies": {"onSuccess": [], "onFailure": [], "onCompletion": []}, "status": "saved", "agent_ref_id": "1"},
+            {"agent": "A2", "dependencies": {"onSuccess": [], "onFailure": [], "onCompletion": []}, "status": "saved", "agent_ref_id": "2"},
+            {"agent": "A3", "dependencies": {"onSuccess": ["A1"], "onFailure": [], "onCompletion": []}, "status": "saved", "agent_ref_id": "3"},
+            {"agent": "A4", "dependencies": {"onSuccess": [], "onFailure": ["A1", "A2"], "onCompletion": []}, "status": "saved", "agent_ref_id": "4"},
+        ],
+    }
+    conn = DummyConn()
+    agent = SimpleNamespace(
+        get_db_connection=lambda: conn,
+        settings=SimpleNamespace(script_user="tester"),
+    )
+    prs = ProcessRoutingService(agent)
+    prs.get_process_details = lambda pid: initial
+    prs.update_agent_status(1, "A4", "running")
+    updated = json.loads(conn.cursor_obj.params[0])
+    assert updated["agents"][3]["status"] == "running"
+    assert updated["agents"][2]["dependencies"]["onSuccess"] == ["A1"]
+    assert updated["agents"][3]["dependencies"]["onFailure"] == ["A1", "A2"]
+
+
+def test_log_run_detail_keeps_agent_statuses():
+    details = {
+        "status": "",
+        "agents": [
+            {"agent": "A1", "dependencies": {"onSuccess": [], "onFailure": [], "onCompletion": []}, "status": "running", "agent_ref_id": "1"},
+            {"agent": "A2", "dependencies": {"onSuccess": ["A1"], "onFailure": [], "onCompletion": []}, "status": "saved", "agent_ref_id": "2"},
+        ],
+    }
+    conn = DummyConn()
+    agent = SimpleNamespace(
+        get_db_connection=lambda: conn,
+        settings=SimpleNamespace(script_user="tester"),
+    )
+    prs = ProcessRoutingService(agent)
+    prs.log_run_detail(
+        process_id=1,
+        process_status="success",
+        process_details=details,
+        process_start_ts=datetime.utcnow(),
+        process_end_ts=datetime.utcnow(),
+        triggered_by="tester",
+    )
+    updated = json.loads(conn.cursor_obj.params[1])
+    assert updated["status"] == "completed"
+    assert updated["agents"][0]["status"] == "running"
+    assert updated["agents"][1]["status"] == "saved"

--- a/tests/test_run_endpoint.py
+++ b/tests/test_run_endpoint.py
@@ -80,9 +80,8 @@ def test_run_endpoint_process_id_executes_flow():
 
     assert prs.status_updates == [(5, 1)]
     # First update marks the run as started
-    assert prs.details_updates[0]["process_status"] == 0
+    assert prs.details_updates[0]["status"] == "started"
     # Final update contains completion information
-    assert prs.details_updates[1]["process_status"] == 1
     assert prs.details_updates[1]["status"] == "completed"
     assert orchestrator.received_flow["agent_type"] == "1"
     assert orchestrator.received_payload == {"foo": "bar"}
@@ -135,4 +134,3 @@ def test_run_endpoint_updates_nested_statuses_independently():
     assert saved["status"] == "completed"
     assert saved["onSuccess"]["status"] == "completed"
     assert saved["onFailure"]["status"] == "saved"
-    assert saved["process_status"] == 1


### PR DESCRIPTION
## Summary
- Remove `process_status` field from `process_details` to strictly match required schema
- Track run progression via top-level `status` field in `/run` endpoint
- Add tests covering second workflow scenario and adjust existing expectations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c18a8909b88332898a32dfd416a2a2