### PR TITLE
Use textual workflow statuses in process routing

### DIFF
--- a/api/routers/run.py
+++ b/api/routers/run.py
@@ -53,10 +53,9 @@ def run_agents(
     if details is None:
         raise HTTPException(status_code=404, detail="Process not found")
 
-    # Initialise workflow progress to ``0`` before kicking off the background
-    # execution so that callers can poll for real-time updates.
-    details["status"] = 0
-
+    # Persist the initial details so that callers can poll for updates while
+    # the workflow executes. The top-level status remains ``saved`` until the
+    # entire flow succeeds or fails.
     try:
         prs.update_process_details(req.process_id, details)
     except Exception:
@@ -90,7 +89,7 @@ def run_agents(
             try:
                 prs.update_process_details(
                     process_id,
-                    {"status": 0, "error": str(exc)},
+                    {"status": "failed", "error": str(exc)},
                 )
             except Exception:
                 logger.exception(

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -417,7 +417,10 @@ class Orchestrator:
             attempt = 0
             result = None
             if prs and process_id is not None:
-                prs.update_agent_status(process_id, step_name, "running")
+                # Mark the agent as ``validated`` to indicate it has started
+                # execution. Downstream status transitions are handled once the
+                # agent completes.
+                prs.update_agent_status(process_id, step_name, "validated")
             while attempt <= retries and not success:
                 attempt += 1
                 context = AgentContext(

--- a/services/process_routing_service.py
+++ b/services/process_routing_service.py
@@ -61,7 +61,11 @@ class ProcessRoutingService:
         Missing fields are populated with sensible defaults.
         """
         details = details.copy() if isinstance(details, dict) else {}
-        details.setdefault("status", "")
+        # Default the overall workflow status to ``saved`` when missing or
+        # empty so that callers can reason about progress using explicit
+        # textual states rather than numeric placeholders.
+        status = details.get("status")
+        details["status"] = status if status else "saved"
         agents = []
         for agent in details.get("agents", []) or []:
             if not isinstance(agent, dict):
@@ -355,16 +359,21 @@ class ProcessRoutingService:
         """
         details = self.get_process_details(process_id, raw=True) or {}
         agents = details.get("agents", [])
-        total = len(agents)
-        completed = 0
         for agent in agents:
             if agent.get("agent") == agent_name:
                 agent["status"] = status
-            if agent.get("status") in ("completed", "failed"):
-                completed += 1
-        progress = int((completed / total) * 100) if total else 0
+
+        # Derive the overall workflow status based on individual agent states.
+        statuses = [a.get("status") for a in agents]
+        if any(s == "failed" for s in statuses):
+            overall = "failed"
+        elif statuses and all(s == "completed" for s in statuses):
+            overall = "completed"
+        else:
+            overall = details.get("status", "saved") or "saved"
+
         details["agents"] = agents
-        details["status"] = progress
+        details["status"] = overall
 
         self.update_process_details(process_id, details, modified_by)
 
@@ -484,19 +493,15 @@ class ProcessRoutingService:
     ) -> Optional[str]:
 
 
-      def _annotate_process_details(details: Optional[Dict[str, Any]], status_progress: int) -> Dict[str, Any]:
-          """Ensure `details` is a dict and annotate top-level progress.
+        def _annotate_process_details(details: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+            """Normalise ``details`` without altering workflow status.
 
-          ``process_details`` describe entire workflows with nested agent
-          dependencies.  Per-agent status updates are performed elsewhere, so
-          this helper only updates the overall numeric ``status`` field to
-          reflect the workflow's progress while preserving the existing
-          structure.
-          """
-          details = self.normalize_process_details(details)
-          details["status"] = status_progress
-
-          return details
+            The per-agent statuses are managed via :meth:`update_agent_status`.
+            When logging run details we simply ensure the payload adheres to the
+            expected schema while preserving any existing top-level ``status``
+            value so that the overall workflow state remains intact.
+            """
+            return self.normalize_process_details(details)
 
         run_id = run_id or str(uuid.uuid4())
         process_start_ts = process_start_ts or datetime.utcnow()
@@ -533,10 +538,8 @@ class ProcessRoutingService:
         else:
             status_text = "failed" if status_int < 0 else "completed"
 
-        status_progress = 100 if ps in success_vals else 0
-
-        # Annotate process_details per-agent with the derived numeric progress
-        annotated_details = _annotate_process_details(process_details, status_progress)
+        # Normalise process_details without mutating the existing workflow status
+        annotated_details = _annotate_process_details(process_details)
 
         raw_payload = {
             "run_id": run_id,

--- a/tests/test_process_details_structure.py
+++ b/tests/test_process_details_structure.py
@@ -12,7 +12,7 @@ def test_normalize_process_details_scenario1():
 
     details = ProcessRoutingService.normalize_process_details(raw)
 
-    assert details["status"] == ""
+    assert details["status"] == "saved"
     assert len(details["agents"]) == 3
     assert details["agents"][0]["dependencies"] == {
         "onSuccess": [],


### PR DESCRIPTION
## Summary
- keep `process_details` top-level `status` as a string
- derive workflow completion/failed state from per-agent updates
- prevent `/run` endpoint from rewriting overall status before execution
- tag agents as `validated` when they begin running
- adjust tests for new status semantics

## Testing
- `pytest tests/test_process_routing_service.py tests/test_process_details_structure.py tests/test_run_endpoint.py tests/test_agent_endpoints.py`
- `pytest` *(fails: module collection errors for unrelated agent tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9a765988332bdc1ae836f4d2162