### PR TITLE
Enable supplier ranking workflow

### DIFF
--- a/tests/test_supplier_ranking_agent.py
+++ b/tests/test_supplier_ranking_agent.py
@@ -8,8 +8,9 @@ import pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.supplier_ranking_agent import SupplierRankingAgent
-from agents.base_agent import AgentContext
+from agents.base_agent import AgentContext, AgentOutput, AgentStatus
 from engines.policy_engine import PolicyEngine
+from orchestration.orchestrator import Orchestrator
 
 
 class DummyNick:
@@ -41,3 +42,44 @@ def test_top_n_parsed_from_query(monkeypatch):
 
     output = agent.run(context)
     assert len(output.data["ranking"]) == 5
+
+
+def test_execute_ranking_flow_extracts_criteria_from_query():
+    """Orchestrator should derive ranking criteria from the free-text query."""
+
+    class DummyPolicyEngine:
+        def __init__(self):
+            self.supplier_policies = [
+                {
+                    "policyName": "WeightAllocationPolicy",
+                    "details": {"rules": {"default_weights": {"price": 1.0, "delivery": 1.0}}},
+                }
+            ]
+            self.last_input = None
+
+        def validate_workflow(self, workflow_name, user_id, input_data):
+            self.last_input = input_data
+            return {"allowed": True, "reason": ""}
+
+    class DummyQueryEngine:
+        def fetch_supplier_data(self, intent):  # pragma: no cover - simple stub
+            return pd.DataFrame([{"supplier_name": "S1", "price": 10, "delivery": 8}])
+
+    class DummyRankingAgent:
+        def execute(self, context):  # pragma: no cover - simple stub
+            assert context.input_data["intent"]["parameters"]["criteria"] == ["price"]
+            return AgentOutput(status=AgentStatus.SUCCESS, data={})
+
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"supplier_ranking": DummyRankingAgent()},
+        policy_engine=DummyPolicyEngine(),
+        query_engine=DummyQueryEngine(),
+        routing_engine=SimpleNamespace(routing_model={}),
+    )
+
+    orchestrator = Orchestrator(nick)
+    result = orchestrator.execute_ranking_flow("Rank suppliers by price")
+
+    assert result["status"] == "completed"
+    assert nick.policy_engine.last_input["criteria"] == ["price"]


### PR DESCRIPTION
## Summary
- derive ranking criteria from user query and feed into supplier ranking workflow
- re-enable policy checks for all workflows
- add orchestrator test for ranking criteria extraction

## Testing
- `pytest tests/test_supplier_ranking_agent.py tests/test_email_drafting_agent.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c27d199b6c8332b27eb4452389be37