### PR TITLE
Enable supplier ranking workflow

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -52,8 +52,30 @@ class Orchestrator:
         self.executor = ThreadPoolExecutor(max_workers=self.settings.max_workers)
 
     def execute_ranking_flow(self, query: str) -> Dict:
-        """Public wrapper for the supplier ranking workflow."""
-        return self.execute_workflow("supplier_ranking", {"query": query})
+        """Public wrapper for the supplier ranking workflow.
+
+        The policy engine requires ranking criteria to be supplied for
+        validation.  When only a free-text query is provided we attempt to
+        derive the criteria by matching known policy terms within the query.
+        If no explicit matches are found we fall back to the full set of
+        default policy criteria so that the workflow still proceeds with
+        reasonable defaults.
+        """
+
+        weight_policy = next(
+            (p for p in self.policy_engine.supplier_policies if p.get("policyName") == "WeightAllocationPolicy"),
+            {},
+        )
+        default_weights = (
+            weight_policy.get("details", {}).get("rules", {}).get("default_weights", {})
+        )
+        lower_query = query.lower()
+        criteria = [c for c in default_weights.keys() if c in lower_query] or list(
+            default_weights.keys()
+        )
+        intent = {"parameters": {"criteria": criteria}}
+        input_data = {"query": query, "criteria": criteria, "intent": intent}
+        return self.execute_workflow("supplier_ranking", input_data)
 
     def execute_ranking_workflow(self, query: str) -> Dict:
         """Backward compatible alias for :meth:`execute_ranking_flow`."""
@@ -183,6 +205,37 @@ class Orchestrator:
         for slug in agent_defs:
             if slug in key_lower or key_lower in slug:
                 return slug
+
+        tokens: List[str] = []
+        for t in re.split(r"[_]+", key_lower):
+            if len(t) <= 2 or t in {"agent", "test", "keerthi", "admin", "user", "service"}:
+                continue
+            if t.endswith("s"):
+                t = t[:-1]
+            tokens.append(t)
+
+        for token in tokens:
+            for slug in agent_defs:
+                if token in slug or slug in token:
+                    return slug
+
+        # Fuzzy match individual tokens or the whole key to tolerate
+        # dynamically generated identifiers (e.g.
+        # ``keerthi_quotes_agent_test_0001``) and minor misspellings.
+        try:  # ``difflib`` is part of the stdlib
+            import difflib
+
+            tokens = re.split(r"[_]+", key_lower)
+            candidates = list(agent_defs.keys())
+            for token in tokens:
+                match = difflib.get_close_matches(token, candidates, n=1, cutoff=0.8)
+                if match:
+                    return match[0]
+            match = difflib.get_close_matches(key_lower, candidates, n=1, cutoff=0.6)
+            if match:
+                return match[0]
+        except Exception:  # pragma: no cover - extremely defensive
+            logger.exception("Fuzzy agent resolution failed for '%s'", raw_key)
         return None
 
     def _get_agent_details(self, agent_spec) -> List[Dict[str, Any]]:
@@ -585,9 +638,7 @@ class Orchestrator:
         return flow
 
     def _validate_workflow(self, workflow_name: str, context: AgentContext) -> bool:
-        """Validate workflow against policies"""
-        if workflow_name == "supplier_ranking":
-            return True
+        """Validate workflow against policies."""
         validation_result = self.policy_engine.validate_workflow(
             workflow_name, context.user_id, context.input_data
         )

--- a/tests/test_agent_resolution.py
+++ b/tests/test_agent_resolution.py
@@ -34,3 +34,18 @@ def test_get_agent_details_parses_array_string():
     details = orch._get_agent_details("{supplier_ranking,quote_evaluation}")
     types = {d["agent_type"] for d in details}
     assert {"supplier_ranking", "quote_evaluation"} <= types
+
+
+def test_canonical_key_fuzzy_matches_dynamic_ids():
+    orch = make_orchestrator()
+    defs = orch._load_agent_definitions()
+
+    slug_quotes = orch._canonical_key(
+        "keerthi_quotes_agent_test_000074_1757585776760", defs
+    )
+    slug_negotiation = orch._canonical_key(
+        "keerthi_negotitiation_test_000078_1757586202506", defs
+    )
+
+    assert slug_quotes == "quote_evaluation"
+    assert slug_negotiation == "negotiation"

--- a/tests/test_supplier_ranking_agent.py
+++ b/tests/test_supplier_ranking_agent.py
@@ -8,8 +8,9 @@ import pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.supplier_ranking_agent import SupplierRankingAgent
-from agents.base_agent import AgentContext
+from agents.base_agent import AgentContext, AgentOutput, AgentStatus
 from engines.policy_engine import PolicyEngine
+from orchestration.orchestrator import Orchestrator
 
 
 class DummyNick:
@@ -41,3 +42,44 @@ def test_top_n_parsed_from_query(monkeypatch):
 
     output = agent.run(context)
     assert len(output.data["ranking"]) == 5
+
+
+def test_execute_ranking_flow_extracts_criteria_from_query():
+    """Orchestrator should derive ranking criteria from the free-text query."""
+
+    class DummyPolicyEngine:
+        def __init__(self):
+            self.supplier_policies = [
+                {
+                    "policyName": "WeightAllocationPolicy",
+                    "details": {"rules": {"default_weights": {"price": 1.0, "delivery": 1.0}}},
+                }
+            ]
+            self.last_input = None
+
+        def validate_workflow(self, workflow_name, user_id, input_data):
+            self.last_input = input_data
+            return {"allowed": True, "reason": ""}
+
+    class DummyQueryEngine:
+        def fetch_supplier_data(self, intent):  # pragma: no cover - simple stub
+            return pd.DataFrame([{"supplier_name": "S1", "price": 10, "delivery": 8}])
+
+    class DummyRankingAgent:
+        def execute(self, context):  # pragma: no cover - simple stub
+            assert context.input_data["intent"]["parameters"]["criteria"] == ["price"]
+            return AgentOutput(status=AgentStatus.SUCCESS, data={})
+
+    nick = SimpleNamespace(
+        settings=SimpleNamespace(script_user="tester", max_workers=1),
+        agents={"supplier_ranking": DummyRankingAgent()},
+        policy_engine=DummyPolicyEngine(),
+        query_engine=DummyQueryEngine(),
+        routing_engine=SimpleNamespace(routing_model={}),
+    )
+
+    orchestrator = Orchestrator(nick)
+    result = orchestrator.execute_ranking_flow("Rank suppliers by price")
+
+    assert result["status"] == "completed"
+    assert nick.policy_engine.last_input["criteria"] == ["price"]


### PR DESCRIPTION
## Summary
- derive ranking criteria from user query and feed into supplier ranking workflow
- re-enable policy checks for all workflows
- add orchestrator test for ranking criteria extraction
- normalise dynamically generated agent identifiers via token and fuzzy matching to avoid runtime failures

## Testing
- `pytest tests/test_agent_resolution.py -q`
- `pytest tests/test_supplier_ranking_agent.py tests/test_email_drafting_agent.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c27d199b6c8332b27eb4452389be37