### PR TITLE
Fix supplier ranking workflow and enhance email drafting agent

### DIFF
--- a/agents/supplier_ranking_agent.py
+++ b/agents/supplier_ranking_agent.py
@@ -24,18 +24,33 @@ class SupplierRankingAgent(BaseAgent):
         self.prompt_library = self._load_json_file('prompts/SupplierRankingAgent_PromptLibrary.json')
         self.justification_template = self._load_json_file('prompts/Justification_Tag_Prompt_Template.json')
         self.policy_engine = agent_nick.policy_engine
+        # Allow the agent to fetch its own supplier data when invoked outside
+        # the standard workflow.
+        self.query_engine = agent_nick.query_engine
 
     def run(self, context: AgentContext) -> AgentOutput:
         logger.info("SupplierRankingAgent: Starting ranking...")
 
-        # 1. Load supplier_data from context
+        # 1. Load supplier_data from context or fetch dynamically
         supplier_data = context.input_data.get('supplier_data')
         if supplier_data is None:
-            return AgentOutput(
-                status=AgentStatus.FAILED,
-                data={},
-                error='No supplier_data provided to SupplierRankingAgent'
-            )
+            try:
+                supplier_data = self.query_engine.fetch_supplier_data(
+                    context.input_data
+                )
+            except Exception:  # pragma: no cover - best effort
+                logger.exception("Failed to fetch supplier data")
+                return AgentOutput(
+                    status=AgentStatus.FAILED,
+                    data={},
+                    error="Failed to fetch supplier data",
+                )
+            if supplier_data is None:
+                return AgentOutput(
+                    status=AgentStatus.FAILED,
+                    data={},
+                    error='No supplier_data provided to SupplierRankingAgent'
+                )
         # Convert to DataFrame
         if isinstance(supplier_data, pd.DataFrame):
             df = supplier_data.copy()

--- a/tests/test_supplier_ranking_agent.py
+++ b/tests/test_supplier_ranking_agent.py
@@ -16,7 +16,13 @@ from orchestration.orchestrator import Orchestrator
 class DummyNick:
     def __init__(self):
         self.policy_engine = PolicyEngine()
-        self.settings = SimpleNamespace(extraction_model="llama3", script_user="tester")
+        self.settings = SimpleNamespace(
+            extraction_model="llama3", script_user="tester"
+        )
+        # Minimal query engine stub for agent initialisation
+        self.query_engine = SimpleNamespace(
+            fetch_supplier_data=lambda *_: []
+        )
 
 
 def test_top_n_parsed_from_query(monkeypatch):


### PR DESCRIPTION
## Summary
- allow `SupplierRankingAgent` to fetch its own data when invoked via `/run`
- emit detailed logging for each agent step in orchestrator flows
- use LLM output to populate `EmailDraftingAgent` emails and mark them sent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2df84dc1c833298f46bf754060884