### PR TITLE
Improve data extraction context and robustness

### DIFF
--- a/utils/nlp.py
+++ b/utils/nlp.py
@@ -19,7 +19,8 @@ from typing import Any, Dict, List, Optional
 from utils.gpu import configure_gpu
 
 try:  # ``transformers`` is optional at runtime
-    from transformers import pipeline  # type: ignore
+    from transformers import pipeline, logging as hf_logging  # type: ignore
+    hf_logging.set_verbosity_error()
 except Exception:  # pragma: no cover - optional dependency
     pipeline = None  # type: ignore
 


### PR DESCRIPTION
## Summary
- enrich purchase order vs invoice context to guide LLM-based extraction
- harden date parsing and line-item persistence
- suppress noisy third-party warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3e10fc2e8833281777f304e67ac5f