### PR TITLE
Fix run payload propagation and improve agent data handling

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -463,7 +463,15 @@ class Orchestrator:
             timeout = step.get("timeout_seconds")
             on_error = step.get("on_error", "fail")
 
-            input_cfg = {**defaults.get("input", {}), **step.get("input", {})}
+            # Merge the global payload with any default or step-specific input
+            # so that agents receive the full context when an explicit ``input``
+            # section is omitted.  Step definitions override defaults, which in
+            # turn override the payload values.
+            input_cfg = {
+                **(payload or {}),
+                **defaults.get("input", {}),
+                **step.get("input", {}),
+            }
             rendered_input = _render(input_cfg)
 
             success = False

--- a/tests/test_email_drafting_agent.py
+++ b/tests/test_email_drafting_agent.py
@@ -58,6 +58,8 @@ def test_email_drafting_agent(monkeypatch):
     assert draft["supplier_id"] == "S1"
     assert draft["rfq_id"].startswith("RFQ-")
     assert f"<!-- RFQ-ID: {draft['rfq_id']} -->" in draft["body"]
+    assert "Dear Acme," in draft["body"]
+    assert "Deadline for submission: 01/01/2025" in draft["body"]
     assert captured["drafts"][0] == draft
 
 

--- a/tests/test_opportunity_miner_agent.py
+++ b/tests/test_opportunity_miner_agent.py
@@ -59,6 +59,27 @@ def test_supplier_consolidation_sets_supplier_id(monkeypatch):
     assert sc and sc[0]["supplier_id"] is not None
 
 
+def test_po_invoice_discrepancy_includes_item_and_supplier(monkeypatch):
+    nick = DummyNick()
+    agent = OpportunityMinerAgent(nick, min_financial_impact=0)
+
+    monkeypatch.setattr(agent, "_output_excel", lambda findings: None)
+    monkeypatch.setattr(agent, "_output_feed", lambda findings: None)
+    monkeypatch.setattr(agent, "_ingest_data", agent._mock_data)
+
+    context = AgentContext(
+        workflow_id="wf3",
+        agent_id="opportunity_miner",
+        user_id="u1",
+        input_data={},
+    )
+
+    output = agent.run(context)
+    findings = [f for f in output.data["findings"] if f["detector_type"] == "PO↔Invoice Discrepancy"]
+    assert findings and findings[0]["supplier_id"] is not None
+    assert findings[0]["item_id"] is not None
+
+
 def test_opportunity_miner_handles_missing_columns(monkeypatch):
     nick = DummyNick()
     agent = OpportunityMinerAgent(nick)


### PR DESCRIPTION
## Summary
- Propagate workflow payload into each step so SupplierRankingAgent receives required supplier data during `/run`
- Personalize email drafts with supplier-specific details and render legacy templates correctly
- Detect PO vs invoice discrepancies using live data with supplier, category, and item identifiers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c62f3240d48332a9d5a7581874818e