### PR TITLE
feat: add metadata to email drafts

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -117,6 +117,10 @@ class BaseAgent:
             )
             result.action_id = action_id
             result.data.setdefault("action_id", action_id)
+            drafts = result.data.get("drafts")
+            if isinstance(drafts, list):
+                for draft in drafts:
+                    draft.setdefault("action_id", action_id)
         logger.info(
             "%s: completed with status %s", self.__class__.__name__, result.status.value
         )

--- a/agents/email_drafting_agent.py
+++ b/agents/email_drafting_agent.py
@@ -121,6 +121,8 @@ class EmailDraftingAgent(BaseAgent):
                 "rfq_id": rfq_id,
                 "subject": subject,
                 "body": body,
+                "sent_status": True,
+                "recipient": self.agent_nick.settings.ses_default_sender,
             }
             drafts.append(draft)
             self._store_draft(draft)

--- a/tests/test_email_drafting_agent.py
+++ b/tests/test_email_drafting_agent.py
@@ -60,6 +60,8 @@ def test_email_drafting_agent(monkeypatch):
     assert f"<!-- RFQ-ID: {draft['rfq_id']} -->" in draft["body"]
     assert "Dear Acme," in draft["body"]
     assert "Deadline for submission: 01/01/2025" in draft["body"]
+    assert draft["sent_status"] is True
+    assert draft["recipient"] == "sender@example.com"
     assert captured["drafts"][0] == draft
 
 


### PR DESCRIPTION
## Summary
- include `sent_status` and `recipient` in each email draft
- propagate `action_id` to individual drafts when logging actions
- test for new email draft fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c824b146088332828fa27c81d4d82d