### PR TITLE
Ensure workflows inject orchestrator metadata

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -109,11 +109,13 @@ class Orchestrator:
 
         try:
             # Create initial context
+            enriched_input: Dict[str, Any] = {**(input_data or {})}
+            enriched_input.setdefault("workflow", workflow_name)
             context = AgentContext(
                 workflow_id=workflow_id,
                 agent_id=workflow_name,
                 user_id=user_id or self.settings.script_user,
-                input_data=input_data,
+                input_data=enriched_input,
             )
 
             # Validate against policies


### PR DESCRIPTION
## Summary
- ensure the orchestrator always includes the workflow name in the initial agent context input so downstream agents receive the mandatory metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c871d85f248332a8369d4099315072