### PR TITLE
Fix opportunity miner workflow requirements

### DIFF
--- a/api/routers/workflows.py
+++ b/api/routers/workflows.py
@@ -125,7 +125,37 @@ class ExtractRequest(BaseModel):
 class OpportunityMiningRequest(BaseModel):
     """Parameters for opportunity mining workflow."""
 
-    min_financial_impact: float = 100.0
+    workflow: str
+    conditions: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Policy specific parameters keyed by requirement name.",
+    )
+    min_financial_impact: float = Field(
+        default=100.0,
+        ge=0,
+        description="Minimum savings required for an opportunity to be returned.",
+    )
+
+    @field_validator("workflow", mode="before")
+    @classmethod
+    def _normalise_workflow(cls, value: Any) -> str:
+        if value is None:
+            raise ValueError("workflow is required")
+        if not isinstance(value, str):
+            value = str(value)
+        workflow = value.strip()
+        if not workflow:
+            raise ValueError("workflow must not be empty")
+        return workflow
+
+    @field_validator("conditions", mode="before")
+    @classmethod
+    def _default_conditions(cls, value: Any) -> Dict[str, Any]:
+        if value is None:
+            return {}
+        if isinstance(value, dict):
+            return value
+        raise ValueError("conditions must be a mapping of field names to values")
 
 
 class QuoteEvaluationRequest(BaseModel):

--- a/tests/test_opportunity_miner_agent.py
+++ b/tests/test_opportunity_miner_agent.py
@@ -305,6 +305,29 @@ def test_price_variance_detection_generates_finding(monkeypatch):
     assert any(evt["status"] == "escalated" for evt in output.data["policy_events"])
 
 
+def test_min_financial_impact_override_filters_findings(monkeypatch):
+    agent = create_agent(monkeypatch)
+    context = build_context(
+        "price_variance_check",
+        {
+            "supplier_id": "SI0001",
+            "item_id": "ITM-001",
+            "actual_price": 11.0,
+            "benchmark_price": 9.0,
+            "quantity": 10,
+            "variance_threshold_pct": 0.05,
+        },
+    )
+    context.input_data["min_financial_impact"] = 50.0
+
+    output = agent.run(context)
+
+    assert output.status == AgentStatus.SUCCESS
+    assert output.data["opportunity_count"] == 0
+    assert output.data["findings"] == []
+    assert output.data["min_financial_impact"] == 50.0
+
+
 def test_volume_consolidation_identifies_costlier_supplier(monkeypatch):
     agent = create_agent(monkeypatch)
     context = build_context(


### PR DESCRIPTION
## Summary
- require workflow metadata and structured conditions when calling the opportunity mining API
- allow the miner agent to honour per-run minimum financial impact thresholds and expose the value in results
- cover the new threshold behaviour with a focused unit test

## Testing
- pytest tests/test_opportunity_miner_agent.py
- pytest tests/test_execute_agent_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68c9011b9d688332b9580783ce03f12e