### PR TITLE
Fix email draft metadata and ensure table exists

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -118,11 +118,12 @@ class BaseAgent:
                 run_id=run_id,
             )
             result.action_id = action_id
-            result.data.setdefault("action_id", action_id)
+            result.data["action_id"] = action_id
             drafts = result.data.get("drafts")
             if isinstance(drafts, list):
                 for draft in drafts:
-                    draft.setdefault("action_id", action_id)
+                    if isinstance(draft, dict):
+                        draft["action_id"] = action_id
         logger.info(
             "%s: completed with status %s", self.__class__.__name__, result.status.value
         )

--- a/tests/test_email_drafting_agent.py
+++ b/tests/test_email_drafting_agent.py
@@ -61,7 +61,7 @@ def test_email_drafting_agent(monkeypatch):
     assert "Dear Acme," in draft["body"]
     assert "Deadline for submission: 01/01/2025" in draft["body"]
     assert draft["sent_status"] is False
-    assert draft["recipient"] == "sender@example.com"
+    assert draft["sender"] == "sender@example.com"
     assert captured["drafts"][0] == draft
 
 


### PR DESCRIPTION
## Summary
- ensure action ids written by the process router are propagated onto email draft payloads
- update the email drafting agent to emit a sender field, track table initialisation, and lazily create the draft storage table
- adjust unit tests to reflect the renamed field

## Testing
- pytest tests/test_email_drafting_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68c9146b41c0833291ca45a30b61a4ce