### PR TITLE
Ensure opportunity-driven ranking and resilient price lookup

### DIFF
--- a/tests/test_opportunity_miner_agent.py
+++ b/tests/test_opportunity_miner_agent.py
@@ -19,6 +19,19 @@ class DummyNick:
         self.settings = SimpleNamespace(script_user="tester")
 
 
+def test_price_expression_falls_back_to_unit_price(monkeypatch):
+    nick = DummyNick()
+    nick.query_engine = None
+    agent = OpportunityMinerAgent(nick)
+
+    monkeypatch.setattr(
+        agent, "_get_table_columns", lambda schema, table: {"unit_price"}
+    )
+
+    expr = agent._price_expression("proc", "po_line_items_agent", "li")
+    assert expr == "li.unit_price"
+
+
 def _sample_tables() -> Dict[str, Any]:
     purchase_orders = pd.DataFrame(
         [


### PR DESCRIPTION
## Summary
- run OpportunityMinerAgent at the start of the ranking workflow and propagate its supplier candidates to downstream agents
- derive supplier price expressions dynamically in OpportunityMinerAgent to avoid missing column errors when querying procurement data
- cover the new orchestration behaviour and price expression fallback with dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c92fc562908332863d0c3bd7c39639