### PR TITLE
Ensure supplier workflows chain opportunity, ranking, and quote evaluation

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -874,14 +874,12 @@ class Orchestrator:
         results: Dict[str, Any] = {}
         input_data = context.input_data
 
-        has_opportunity_payload = bool(
-            input_data.get("workflow") or input_data.get("conditions")
-        )
         should_run_opportunity = (
             "opportunity_miner" in self.agents
-            and has_opportunity_payload
             and not input_data.get("skip_opportunity_step", False)
         )
+
+        supplier_candidates: List[str] = []
 
         if should_run_opportunity:
             opp_context = self._create_child_context(context, "opportunity_miner", {})
@@ -894,19 +892,41 @@ class Orchestrator:
                 )
                 return results
 
-            supplier_candidates = (
+            supplier_candidates_raw = (
                 (opp_result.pass_fields or {}).get("supplier_candidates")
                 or opp_result.data.get("supplier_candidates")
                 or []
             )
+            seen_candidates: set[str] = set()
+            for candidate in supplier_candidates_raw:
+                if candidate is None:
+                    continue
+                candidate_str = str(candidate).strip()
+                if not candidate_str or candidate_str in seen_candidates:
+                    continue
+                seen_candidates.add(candidate_str)
+                supplier_candidates.append(candidate_str)
+
             if supplier_candidates:
-                ordered = list(dict.fromkeys(str(s) for s in supplier_candidates))
-                input_data["supplier_candidates"] = ordered
+                input_data["supplier_candidates"] = supplier_candidates
             else:
                 logger.info(
                     "OpportunityMinerAgent returned no supplier candidates; skipping ranking stage"
                 )
                 return results
+        else:
+            existing_candidates = input_data.get("supplier_candidates") or []
+            seen_candidates: set[str] = set()
+            for candidate in existing_candidates:
+                if candidate is None:
+                    continue
+                candidate_str = str(candidate).strip()
+                if not candidate_str or candidate_str in seen_candidates:
+                    continue
+                seen_candidates.add(candidate_str)
+                supplier_candidates.append(candidate_str)
+            if supplier_candidates:
+                input_data["supplier_candidates"] = supplier_candidates
 
         # Get supplier data for ranking
         input_data["supplier_data"] = self.query_engine.fetch_supplier_data(
@@ -914,23 +934,57 @@ class Orchestrator:
         )
 
         ranking_result = self._execute_agent("supplier_ranking", context)
-        results["ranking"] = ranking_result.data
+        if not ranking_result:
+            return results
 
-        downstream_agents = [
-            agent
-            for agent in (ranking_result.next_agents or [])
-            if agent != "OpportunityMinerAgent"
-        ]
+        results["ranking"] = ranking_result.data or {}
+
+        if ranking_result.status != AgentStatus.SUCCESS:
+            return results
+
+        pass_fields: Dict[str, Any] = dict(ranking_result.pass_fields or {})
+        if supplier_candidates and "supplier_candidates" not in pass_fields:
+            pass_fields["supplier_candidates"] = supplier_candidates
+
+        ranking_payload = pass_fields.get("ranking")
+        if not ranking_payload:
+            ranking_payload = results["ranking"].get("ranking") if isinstance(results["ranking"], dict) else None
+            if ranking_payload:
+                pass_fields["ranking"] = ranking_payload
+
+        downstream_agents: List[str] = []
+        seen_downstream: set[str] = set()
+
+        def _normalise_agent(candidate: str) -> Optional[str]:
+            if not candidate:
+                return None
+            if candidate in self.agents:
+                return candidate
+            resolved = self._resolve_agent_name(candidate)
+            return resolved if resolved in self.agents else None
+
+        if ranking_payload and "quote_evaluation" in self.agents:
+            downstream_agents.append("quote_evaluation")
+            seen_downstream.add("quote_evaluation")
+
+        for agent in ranking_result.next_agents or []:
+            normalised = _normalise_agent(agent)
+            if not normalised or normalised == "opportunity_miner":
+                continue
+            if normalised not in seen_downstream:
+                downstream_agents.append(normalised)
+                seen_downstream.add(normalised)
 
         if downstream_agents:
             downstream_results: Dict[str, Any] = {}
-            pass_fields = ranking_result.pass_fields or {}
             for agent_name in downstream_agents:
                 child_ctx = self._create_child_context(context, agent_name, pass_fields)
                 agent_result = self._execute_agent(agent_name, child_ctx)
                 downstream_results[agent_name] = (
                     agent_result.data if agent_result else {}
                 )
+                if agent_result and agent_result.pass_fields:
+                    pass_fields.update(agent_result.pass_fields)
             results["downstream_results"] = downstream_results
 
         if should_run_opportunity or downstream_agents:
@@ -965,18 +1019,77 @@ class Orchestrator:
         opp_result = self._execute_agent("opportunity_miner", context)
         results: Dict[str, Any] = {"opportunities": opp_result.data if opp_result else {}}
 
-        candidates = opp_result.data.get("supplier_candidates", []) if opp_result else []
+        candidates_raw = opp_result.data.get("supplier_candidates", []) if opp_result else []
+        seen_candidates: set[str] = set()
+        candidates: List[str] = []
+        for candidate in candidates_raw:
+            if candidate is None:
+                continue
+            candidate_str = str(candidate).strip()
+            if not candidate_str or candidate_str in seen_candidates:
+                continue
+            seen_candidates.add(candidate_str)
+            candidates.append(candidate_str)
+
         if candidates:
+            pass_payload: Dict[str, Any] = {"supplier_candidates": candidates}
             rank_ctx = self._create_child_context(
-                context, "supplier_ranking", {"supplier_candidates": candidates}
+                context, "supplier_ranking", pass_payload
+            )
+            rank_ctx.input_data["supplier_data"] = self.query_engine.fetch_supplier_data(
+                rank_ctx.input_data
             )
             rank_res = self._execute_agent("supplier_ranking", rank_ctx)
             results["ranking"] = rank_res.data if rank_res else {}
 
+            ranking_payload = []
+            if rank_res:
+                ranking_payload = (
+                    (rank_res.pass_fields or {}).get("ranking")
+                    or (rank_res.data or {}).get("ranking")
+                    or []
+                )
+
+            pass_fields: Dict[str, Any] = dict((rank_res.pass_fields or {}) if rank_res else {})
+            if candidates and "supplier_candidates" not in pass_fields:
+                pass_fields["supplier_candidates"] = candidates
+            if ranking_payload and "ranking" not in pass_fields:
+                pass_fields["ranking"] = ranking_payload
+
+            if ranking_payload and "quote_evaluation" in self.agents:
+                quote_ctx = self._create_child_context(
+                    context, "quote_evaluation", pass_fields
+                )
+                quote_res = self._execute_agent("quote_evaluation", quote_ctx)
+                if quote_res:
+                    results["quote_evaluation"] = quote_res.data or {}
+                    if quote_res.pass_fields:
+                        pass_fields.update(quote_res.pass_fields)
+
+                    if quote_res.next_agents:
+                        downstream: Dict[str, Any] = {}
+                        for agent_name in quote_res.next_agents:
+                            normalised = self._resolve_agent_name(agent_name)
+                            if normalised not in self.agents:
+                                continue
+                            if normalised in {"opportunity_miner", "supplier_ranking", "quote_evaluation"}:
+                                continue
+                            child_ctx = self._create_child_context(
+                                context, normalised, pass_fields
+                            )
+                            agent_res = self._execute_agent(normalised, child_ctx)
+                            downstream[normalised] = agent_res.data if agent_res else {}
+                            if agent_res and agent_res.pass_fields:
+                                pass_fields.update(agent_res.pass_fields)
+                        if downstream:
+                            results.setdefault("downstream_results", {}).update(downstream)
+
             email_input = {
-                "ranking": rank_res.data.get("ranking", []) if rank_res else [],
+                "ranking": ranking_payload,
                 "findings": opp_result.data.get("findings", []) if opp_result else [],
             }
+            if "quote_evaluation" in results:
+                email_input["quotes"] = results["quote_evaluation"].get("quotes")
             email_ctx = self._create_child_context(context, "email_drafting", email_input)
             email_res = self._execute_agent("email_drafting", email_ctx)
             results["email_drafts"] = email_res.data if email_res else {}


### PR DESCRIPTION
## Summary
- ensure the supplier ranking workflow orchestrates opportunity mining, supplier data retrieval, and quote evaluation in sequence while passing ranking context downstream
- extend the opportunity-to-RFQ workflow to reuse supplier data, trigger quote evaluation, and surface downstream results alongside email drafting inputs
- update the agent flow test to cover the full opportunity → ranking → quote evaluation pipeline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9416b068c83328752b18c8c8414d7