### PR TITLE
Extend quote evaluation to query procurement quote tables

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -874,14 +874,12 @@ class Orchestrator:
         results: Dict[str, Any] = {}
         input_data = context.input_data
 
-        has_opportunity_payload = bool(
-            input_data.get("workflow") or input_data.get("conditions")
-        )
         should_run_opportunity = (
             "opportunity_miner" in self.agents
-            and has_opportunity_payload
             and not input_data.get("skip_opportunity_step", False)
         )
+
+        supplier_candidates: List[str] = []
 
         if should_run_opportunity:
             opp_context = self._create_child_context(context, "opportunity_miner", {})
@@ -894,19 +892,41 @@ class Orchestrator:
                 )
                 return results
 
-            supplier_candidates = (
+            supplier_candidates_raw = (
                 (opp_result.pass_fields or {}).get("supplier_candidates")
                 or opp_result.data.get("supplier_candidates")
                 or []
             )
+            seen_candidates: set[str] = set()
+            for candidate in supplier_candidates_raw:
+                if candidate is None:
+                    continue
+                candidate_str = str(candidate).strip()
+                if not candidate_str or candidate_str in seen_candidates:
+                    continue
+                seen_candidates.add(candidate_str)
+                supplier_candidates.append(candidate_str)
+
             if supplier_candidates:
-                ordered = list(dict.fromkeys(str(s) for s in supplier_candidates))
-                input_data["supplier_candidates"] = ordered
+                input_data["supplier_candidates"] = supplier_candidates
             else:
                 logger.info(
                     "OpportunityMinerAgent returned no supplier candidates; skipping ranking stage"
                 )
                 return results
+        else:
+            existing_candidates = input_data.get("supplier_candidates") or []
+            seen_candidates: set[str] = set()
+            for candidate in existing_candidates:
+                if candidate is None:
+                    continue
+                candidate_str = str(candidate).strip()
+                if not candidate_str or candidate_str in seen_candidates:
+                    continue
+                seen_candidates.add(candidate_str)
+                supplier_candidates.append(candidate_str)
+            if supplier_candidates:
+                input_data["supplier_candidates"] = supplier_candidates
 
         # Get supplier data for ranking
         input_data["supplier_data"] = self.query_engine.fetch_supplier_data(
@@ -914,23 +934,57 @@ class Orchestrator:
         )
 
         ranking_result = self._execute_agent("supplier_ranking", context)
-        results["ranking"] = ranking_result.data
+        if not ranking_result:
+            return results
 
-        downstream_agents = [
-            agent
-            for agent in (ranking_result.next_agents or [])
-            if agent != "OpportunityMinerAgent"
-        ]
+        results["ranking"] = ranking_result.data or {}
+
+        if ranking_result.status != AgentStatus.SUCCESS:
+            return results
+
+        pass_fields: Dict[str, Any] = dict(ranking_result.pass_fields or {})
+        if supplier_candidates and "supplier_candidates" not in pass_fields:
+            pass_fields["supplier_candidates"] = supplier_candidates
+
+        ranking_payload = pass_fields.get("ranking")
+        if not ranking_payload:
+            ranking_payload = results["ranking"].get("ranking") if isinstance(results["ranking"], dict) else None
+            if ranking_payload:
+                pass_fields["ranking"] = ranking_payload
+
+        downstream_agents: List[str] = []
+        seen_downstream: set[str] = set()
+
+        def _normalise_agent(candidate: str) -> Optional[str]:
+            if not candidate:
+                return None
+            if candidate in self.agents:
+                return candidate
+            resolved = self._resolve_agent_name(candidate)
+            return resolved if resolved in self.agents else None
+
+        if ranking_payload and "quote_evaluation" in self.agents:
+            downstream_agents.append("quote_evaluation")
+            seen_downstream.add("quote_evaluation")
+
+        for agent in ranking_result.next_agents or []:
+            normalised = _normalise_agent(agent)
+            if not normalised or normalised == "opportunity_miner":
+                continue
+            if normalised not in seen_downstream:
+                downstream_agents.append(normalised)
+                seen_downstream.add(normalised)
 
         if downstream_agents:
             downstream_results: Dict[str, Any] = {}
-            pass_fields = ranking_result.pass_fields or {}
             for agent_name in downstream_agents:
                 child_ctx = self._create_child_context(context, agent_name, pass_fields)
                 agent_result = self._execute_agent(agent_name, child_ctx)
                 downstream_results[agent_name] = (
                     agent_result.data if agent_result else {}
                 )
+                if agent_result and agent_result.pass_fields:
+                    pass_fields.update(agent_result.pass_fields)
             results["downstream_results"] = downstream_results
 
         if should_run_opportunity or downstream_agents:
@@ -965,18 +1019,77 @@ class Orchestrator:
         opp_result = self._execute_agent("opportunity_miner", context)
         results: Dict[str, Any] = {"opportunities": opp_result.data if opp_result else {}}
 
-        candidates = opp_result.data.get("supplier_candidates", []) if opp_result else []
+        candidates_raw = opp_result.data.get("supplier_candidates", []) if opp_result else []
+        seen_candidates: set[str] = set()
+        candidates: List[str] = []
+        for candidate in candidates_raw:
+            if candidate is None:
+                continue
+            candidate_str = str(candidate).strip()
+            if not candidate_str or candidate_str in seen_candidates:
+                continue
+            seen_candidates.add(candidate_str)
+            candidates.append(candidate_str)
+
         if candidates:
+            pass_payload: Dict[str, Any] = {"supplier_candidates": candidates}
             rank_ctx = self._create_child_context(
-                context, "supplier_ranking", {"supplier_candidates": candidates}
+                context, "supplier_ranking", pass_payload
+            )
+            rank_ctx.input_data["supplier_data"] = self.query_engine.fetch_supplier_data(
+                rank_ctx.input_data
             )
             rank_res = self._execute_agent("supplier_ranking", rank_ctx)
             results["ranking"] = rank_res.data if rank_res else {}
 
+            ranking_payload = []
+            if rank_res:
+                ranking_payload = (
+                    (rank_res.pass_fields or {}).get("ranking")
+                    or (rank_res.data or {}).get("ranking")
+                    or []
+                )
+
+            pass_fields: Dict[str, Any] = dict((rank_res.pass_fields or {}) if rank_res else {})
+            if candidates and "supplier_candidates" not in pass_fields:
+                pass_fields["supplier_candidates"] = candidates
+            if ranking_payload and "ranking" not in pass_fields:
+                pass_fields["ranking"] = ranking_payload
+
+            if ranking_payload and "quote_evaluation" in self.agents:
+                quote_ctx = self._create_child_context(
+                    context, "quote_evaluation", pass_fields
+                )
+                quote_res = self._execute_agent("quote_evaluation", quote_ctx)
+                if quote_res:
+                    results["quote_evaluation"] = quote_res.data or {}
+                    if quote_res.pass_fields:
+                        pass_fields.update(quote_res.pass_fields)
+
+                    if quote_res.next_agents:
+                        downstream: Dict[str, Any] = {}
+                        for agent_name in quote_res.next_agents:
+                            normalised = self._resolve_agent_name(agent_name)
+                            if normalised not in self.agents:
+                                continue
+                            if normalised in {"opportunity_miner", "supplier_ranking", "quote_evaluation"}:
+                                continue
+                            child_ctx = self._create_child_context(
+                                context, normalised, pass_fields
+                            )
+                            agent_res = self._execute_agent(normalised, child_ctx)
+                            downstream[normalised] = agent_res.data if agent_res else {}
+                            if agent_res and agent_res.pass_fields:
+                                pass_fields.update(agent_res.pass_fields)
+                        if downstream:
+                            results.setdefault("downstream_results", {}).update(downstream)
+
             email_input = {
-                "ranking": rank_res.data.get("ranking", []) if rank_res else [],
+                "ranking": ranking_payload,
                 "findings": opp_result.data.get("findings", []) if opp_result else [],
             }
+            if "quote_evaluation" in results:
+                email_input["quotes"] = results["quote_evaluation"].get("quotes")
             email_ctx = self._create_child_context(context, "email_drafting", email_input)
             email_res = self._execute_agent("email_drafting", email_ctx)
             results["email_drafts"] = email_res.data if email_res else {}

--- a/tests/test_quote_evaluation_agent.py
+++ b/tests/test_quote_evaluation_agent.py
@@ -1,5 +1,7 @@
 import os
 import sys
+from datetime import date, datetime
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -63,6 +65,7 @@ def _mock_quotes(*args, **kwargs):
 def test_quote_evaluation_agent_run(monkeypatch):
     nick = DummyNick()
     agent = QuoteEvaluationAgent(nick)
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", lambda *_, **__: [])
     monkeypatch.setattr(agent, "_fetch_quotes", _mock_quotes)
     context = AgentContext(
         workflow_id="wf1",
@@ -85,6 +88,7 @@ def test_quote_evaluation_handles_no_quotes(monkeypatch):
     """Agent should succeed gracefully when no quotes are found."""
     nick = DummyNick()
     agent = QuoteEvaluationAgent(nick)
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", lambda *_, **__: [])
     monkeypatch.setattr(agent, "_fetch_quotes", lambda *_, **__: [])
     context = AgentContext(
         workflow_id="wf_empty",
@@ -105,6 +109,7 @@ def test_quote_evaluation_handles_no_quotes_message(monkeypatch):
     """Agent should succeed gracefully when no quotes are found."""
     nick = DummyNick()
     agent = QuoteEvaluationAgent(nick)
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", lambda *_, **__: [])
     monkeypatch.setattr(agent, "_fetch_quotes", lambda *_, **__: [])
     context = AgentContext(
         workflow_id="wf_empty",
@@ -123,6 +128,13 @@ def test_quote_evaluation_limits_to_ranked_suppliers(monkeypatch):
     agent = QuoteEvaluationAgent(nick)
 
     captured = {}
+    captured_db = {}
+
+    def mock_db_fetch(supplier_names, supplier_ids, product_category=None):
+        captured_db["supplier_names"] = supplier_names
+        captured_db["supplier_ids"] = supplier_ids
+        captured_db["product_category"] = product_category
+        return []
 
     def mock_fetch(supplier_names, supplier_ids=None, product_category=None):
         captured["supplier_names"] = supplier_names
@@ -159,6 +171,7 @@ def test_quote_evaluation_limits_to_ranked_suppliers(monkeypatch):
             },
         ]
 
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", mock_db_fetch)
     monkeypatch.setattr(agent, "_fetch_quotes", mock_fetch)
 
     ranking = [
@@ -177,6 +190,12 @@ def test_quote_evaluation_limits_to_ranked_suppliers(monkeypatch):
 
     output = agent.run(context)
 
+    assert captured_db["supplier_names"] == [
+        "Supplier C",
+        "Supplier A",
+        "Supplier B",
+    ]
+    assert captured_db["supplier_ids"] == []
     assert captured["supplier_names"] == [
         "Supplier C",
         "Supplier A",
@@ -194,6 +213,13 @@ def test_quote_evaluation_uses_supplier_ids(monkeypatch):
     agent = QuoteEvaluationAgent(nick)
 
     captured = {}
+    captured_db = {}
+
+    def mock_db_fetch(supplier_names, supplier_ids, product_category=None):
+        captured_db["supplier_names"] = supplier_names
+        captured_db["supplier_ids"] = supplier_ids
+        captured_db["product_category"] = product_category
+        return []
 
     def mock_fetch(supplier_names, supplier_ids=None, product_category=None):
         captured["supplier_names"] = supplier_names
@@ -222,6 +248,7 @@ def test_quote_evaluation_uses_supplier_ids(monkeypatch):
             },
         ]
 
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", mock_db_fetch)
     monkeypatch.setattr(agent, "_fetch_quotes", mock_fetch)
 
     ranking = [
@@ -239,6 +266,8 @@ def test_quote_evaluation_uses_supplier_ids(monkeypatch):
 
     output = agent.run(context)
 
+    assert captured_db["supplier_names"] == []
+    assert captured_db["supplier_ids"] == ["S100", "S200", "S300"]
     assert captured["supplier_names"] == []
     assert captured["supplier_ids"] == ["S100", "S200", "S300"]
 
@@ -265,6 +294,7 @@ class DummyOrchestrator:
 def test_quote_evaluation_endpoint(monkeypatch):
     nick = DummyNick()
     agent = QuoteEvaluationAgent(nick)
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", lambda *_, **__: [])
     monkeypatch.setattr(agent, "_fetch_quotes", _mock_quotes)
     app = FastAPI()
     app.include_router(router)
@@ -350,6 +380,187 @@ def test_fetch_quotes_handles_missing_supplier_index(monkeypatch):
     assert quotes[0]["quote_file_s3_path"] == "s3://bucket/q1.pdf"
 
 
+def test_fetch_quotes_from_database_enriches_results():
+    nick = DummyNick()
+
+    quote_rows = [
+        (
+            "Q1",
+            "S1",
+            "Supplier One",
+            "B1",
+            date(2024, 5, 1),
+            date(2024, 6, 1),
+            "USD",
+            Decimal("120.00"),
+            Decimal("5.00"),
+            Decimal("6.00"),
+            Decimal("126.00"),
+            "PO1",
+            "US",
+            "NA",
+            "NO",
+            "AUTO",
+            "Widget contract",
+            datetime(2024, 5, 1, 10, 0, 0),
+            "tester",
+            "tester",
+            datetime(2024, 5, 2, 10, 0, 0),
+        )
+    ]
+    line_rows = [
+        (
+            "Q1",
+            "QL1",
+            1,
+            "I1",
+            "Widget Basic",
+            10,
+            "EA",
+            Decimal("12.00"),
+            Decimal("120.00"),
+            Decimal("5.00"),
+            Decimal("6.00"),
+            Decimal("126.00"),
+            "USD",
+        )
+    ]
+
+    quote_columns = [
+        "quote_id",
+        "supplier_id",
+        "supplier_name",
+        "buyer_id",
+        "quote_date",
+        "validity_date",
+        "currency",
+        "total_amount",
+        "tax_percent",
+        "tax_amount",
+        "total_amount_incl_tax",
+        "po_id",
+        "country",
+        "region",
+        "ai_flag_required",
+        "trigger_type",
+        "trigger_context_description",
+        "created_date",
+        "created_by",
+        "last_modified_by",
+        "last_modified_date",
+    ]
+    line_columns = [
+        "quote_id",
+        "quote_line_id",
+        "line_number",
+        "item_id",
+        "item_description",
+        "quantity",
+        "unit_of_measure",
+        "unit_price",
+        "line_total",
+        "tax_percent",
+        "tax_amount",
+        "total_amount",
+        "currency",
+    ]
+
+    class DummyCursor:
+        def __init__(self, connection):
+            self.connection = connection
+            self.description = []
+            self._rows = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params=None):
+            self.connection.queries.append((sql, params))
+            if "FROM proc.quote_agent" in sql:
+                self._rows = self.connection.quotes
+                self.description = [(col,) for col in self.connection.quote_columns]
+            elif "FROM proc.quote_line_items_agent" in sql:
+                self._rows = self.connection.lines
+                self.description = [(col,) for col in self.connection.line_columns]
+            else:
+                self._rows = []
+                self.description = []
+
+        def fetchall(self):
+            return list(self._rows)
+
+    class DummyConnection:
+        def __init__(self, quotes, lines, quote_cols, line_cols):
+            self.quotes = quotes
+            self.lines = lines
+            self.quote_columns = quote_cols
+            self.line_columns = line_cols
+            self.queries = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return DummyCursor(self)
+
+    connection = DummyConnection(quote_rows, line_rows, quote_columns, line_columns)
+    nick.get_db_connection = lambda: connection
+
+    agent = QuoteEvaluationAgent(nick)
+    quotes = agent._fetch_quotes_from_database(["Supplier One"], ["S1"])
+
+    assert len(quotes) == 1
+    record = quotes[0]
+    assert record["supplier_id"] == "S1"
+    assert record["line_items_count"] == 1
+    assert record["line_items"][0]["item_description"] == "Widget Basic"
+    assert record["avg_unit_price"] == pytest.approx(12.0)
+    assert record["total_line_amount"] == pytest.approx(120.0)
+    assert record["total_amount"] == Decimal("120.00")
+    assert connection.queries[0][0].strip().startswith("SELECT")
+
+
+def test_quote_evaluation_uses_supplier_candidates(monkeypatch):
+    nick = DummyNick()
+    agent = QuoteEvaluationAgent(nick)
+
+    captured_db = {}
+    captured_vector = {}
+
+    def mock_db_fetch(supplier_names, supplier_ids, product_category=None):
+        captured_db["names"] = supplier_names
+        captured_db["ids"] = supplier_ids
+        return []
+
+    def mock_fetch(supplier_names, supplier_ids=None, product_category=None):
+        captured_vector["names"] = supplier_names
+        captured_vector["ids"] = supplier_ids
+        return []
+
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", mock_db_fetch)
+    monkeypatch.setattr(agent, "_fetch_quotes", mock_fetch)
+
+    context = AgentContext(
+        workflow_id="wf_candidates",
+        agent_id="quote_evaluation",
+        user_id="u1",
+        input_data={"supplier_candidates": ["S10", "S20"]},
+    )
+
+    output = agent.run(context)
+
+    assert output.status == AgentStatus.SUCCESS
+    assert captured_db["ids"] == ["S10", "S20"]
+    assert captured_vector["ids"] == ["S10", "S20"]
+    assert output.data.get("message") == "No quotes found"
+
+
 def test_process_handles_empty_product_type(monkeypatch):
     nick = DummyNick()
     agent = QuoteEvaluationAgent(nick)
@@ -359,6 +570,7 @@ def test_process_handles_empty_product_type(monkeypatch):
         capture_fetch.captured_ids = supplier_ids
         return _mock_quotes()
 
+    monkeypatch.setattr(agent, "_fetch_quotes_from_database", lambda *_, **__: [])
     monkeypatch.setattr(agent, "_fetch_quotes", capture_fetch)
     context = AgentContext(
         workflow_id="wf3",


### PR DESCRIPTION
## Summary
- integrate supplier ranking and candidate identifiers when sourcing quotes and merge database results with the existing vector-based fetch to keep evaluations populated
- pull quote and line item data from `proc.quote_agent` and `proc.quote_line_items_agent`, enriching the standardized payload with commercial metadata and normalizing numeric/date fields
- expand the quote evaluation test suite to cover database retrieval helpers, supplier candidate propagation, and the updated filtering behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9416b068c83328752b18c8c8414d7