### PR TITLE
Ensure quote comparison uses evaluated quotes

### DIFF
--- a/agent_definitions.json
+++ b/agent_definitions.json
@@ -13,6 +13,13 @@
   },
 
   {
+    "agentId": 3,
+    "agentType": "QuoteComparisonAgent",
+    "description": "Aggregates historical quotes into a comparable structure for downstream evaluation.",
+    "dependencies": ["db_client"]
+  },
+
+  {
     "agentId": 4,
     "agentType": "OpportunityMinerAgent",
     "description": "Identifies procurement anomalies and savings opportunities.",

--- a/agents/quote_comparison_agent.py
+++ b/agents/quote_comparison_agent.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Set
+from decimal import Decimal
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import pandas as pd
 
@@ -22,7 +23,27 @@ class QuoteComparisonAgent(BaseAgent):
 
     def run(self, context: AgentContext) -> AgentOutput:
         supplier_ids = self._collect_supplier_ids(context.input_data)
-        weight_entry = self._prepare_weight_entry(context.input_data.get("weightings") or context.input_data.get("weights") or {})
+        supplier_names = self._collect_supplier_names(context.input_data)
+        weight_entry = self._prepare_weight_entry(
+            context.input_data.get("weightings")
+            or context.input_data.get("weights")
+            or {}
+        )
+
+        passed_quotes = self._extract_passed_quotes(context.input_data)
+        if passed_quotes:
+            formatted, has_suppliers = self._build_from_passed_quotes(
+                passed_quotes,
+                supplier_ids,
+                supplier_names,
+                weight_entry,
+            )
+            if formatted is not None and has_suppliers:
+                return AgentOutput(
+                    status=AgentStatus.SUCCESS,
+                    data={"comparison": formatted},
+                    pass_fields={"comparison": formatted},
+                )
 
         quotes = self._read_table("proc.quote_agent")
         quote_lines = self._read_table("proc.quote_line_items_agent")
@@ -56,7 +77,9 @@ class QuoteComparisonAgent(BaseAgent):
                 pass_fields={"comparison": result},
             )
 
-        merged = quote_lines.merge(quotes, on="quote_id", how="left", suffixes=("_line", ""))
+        merged = quote_lines.merge(
+            quotes, on="quote_id", how="left", suffixes=("_line", "")
+        )
         merged["supplier_id"] = merged["supplier_id"].astype(str)
 
         numeric_cols = {
@@ -85,8 +108,11 @@ class QuoteComparisonAgent(BaseAgent):
             "quantity": "sum",
             "tenure_days": "mean",
             "quote_id": "nunique",
+            "quote_file_s3_path": "first",
         }
-        available_aggs = {col: func for col, func in aggregations.items() if col in merged.columns}
+        available_aggs = {
+            col: func for col, func in aggregations.items() if col in merged.columns
+        }
         summary = merged.groupby("supplier_id").agg(available_aggs).reset_index()
 
         if suppliers is not None and not suppliers.empty:
@@ -119,6 +145,218 @@ class QuoteComparisonAgent(BaseAgent):
             data={"comparison": results},
             pass_fields={"comparison": results},
         )
+
+    def _extract_passed_quotes(self, input_data: Dict) -> List[Dict]:
+        for key in ("comparison", "quotes"):
+            value = input_data.get(key)
+            if isinstance(value, list) and value:
+                return value
+        return []
+
+    def _collect_supplier_names(self, input_data: Dict) -> Set[str]:
+        names: Set[str] = set()
+        for key in ("supplier_names", "supplier_name"):
+            raw = input_data.get(key)
+            names.update(self._normalise_tokens(raw))
+
+        ranking = input_data.get("ranking", [])
+        if isinstance(ranking, list):
+            for entry in ranking:
+                if isinstance(entry, dict):
+                    token = entry.get("name") or entry.get("supplier_name")
+                    if token:
+                        names.add(self._normalise_string(token))
+
+        findings = input_data.get("findings", [])
+        if isinstance(findings, list):
+            for finding in findings:
+                if isinstance(finding, dict):
+                    token = finding.get("supplier_name") or finding.get("supplier")
+                    if token:
+                        names.add(self._normalise_string(token))
+
+        return {name for name in names if name}
+
+    def _normalise_tokens(self, value: Optional[Iterable]) -> Set[str]:
+        if value is None:
+            return set()
+        if isinstance(value, (str, int, float, Decimal)):
+            return {self._normalise_string(value)}
+        tokens: Set[str] = set()
+        for item in value:
+            normalised = self._normalise_string(item)
+            if normalised:
+                tokens.add(normalised)
+        return tokens
+
+    @staticmethod
+    def _normalise_string(value: Optional[object]) -> str:
+        if value is None:
+            return ""
+        text = str(value).strip()
+        return text.lower()
+
+    def _build_from_passed_quotes(
+        self,
+        quotes: Sequence[Dict],
+        supplier_ids: Set[str],
+        supplier_names: Set[str],
+        weight_entry: Dict,
+    ) -> Tuple[Optional[List[Dict]], bool]:
+        supplier_id_tokens = {
+            token
+            for token in (self._normalise_string(v) for v in supplier_ids)
+            if token
+        }
+        supplier_name_tokens = {name for name in supplier_names if name}
+
+        weight_row = None
+        supplier_rows: List[Dict] = []
+        has_supplier_entries = False
+
+        for entry in quotes:
+            if not isinstance(entry, dict):
+                continue
+
+            name = str(entry.get("name", "")).strip()
+            if name.lower() == "weighting":
+                weight_row = self._merge_weight_entries(entry, weight_entry)
+                continue
+
+            has_supplier_entries = True
+            if not self._entry_matches_suppliers(
+                entry, supplier_id_tokens, supplier_name_tokens
+            ):
+                continue
+            supplier_rows.append(self._format_passed_quote(entry))
+
+        if not has_supplier_entries:
+            return None, False
+
+        if not supplier_rows:
+            return None, True
+
+        weight_row = weight_row or weight_entry
+        results = [weight_row]
+        results.extend(supplier_rows)
+        return results, True
+
+    def _entry_matches_suppliers(
+        self,
+        entry: Dict,
+        supplier_ids: Set[str],
+        supplier_names: Set[str],
+    ) -> bool:
+        if not supplier_ids and not supplier_names:
+            return True
+
+        candidates = set()
+        for key in ("supplier_id", "quote_id"):
+            candidate = entry.get(key)
+            if candidate is not None:
+                token = self._normalise_string(candidate)
+                if token:
+                    candidates.add(token)
+
+        for key in ("name", "supplier_name"):
+            candidate = entry.get(key)
+            if isinstance(candidate, str):
+                token = candidate.strip().lower()
+                if token:
+                    candidates.add(token)
+
+        if supplier_ids and candidates & supplier_ids:
+            return True
+        if supplier_names and candidates & supplier_names:
+            return True
+        return False
+
+    def _merge_weight_entries(self, source: Dict, fallback: Dict) -> Dict:
+        merged = dict(fallback)
+        numeric_keys = ("total_spend", "total_cost", "unit_price", "volume")
+        for key in numeric_keys:
+            value = source.get(key)
+            if not self._is_null(value):
+                merged[key] = self._to_float(value)
+
+        if not self._is_null(source.get("tenure")):
+            merged["tenure"] = source.get("tenure")
+
+        path = source.get("quote_file_s3_path")
+        if isinstance(path, str) and path.strip():
+            merged["quote_file_s3_path"] = path.strip()
+        elif source.get("quote_file_s3_path") is None:
+            merged["quote_file_s3_path"] = None
+
+        return merged
+
+    def _format_passed_quote(self, entry: Dict) -> Dict:
+        supplier_id = entry.get("supplier_id")
+        supplier_identifier = self._clean_identifier(supplier_id)
+        supplier_name = entry.get("name") or entry.get("supplier_name")
+        if not supplier_name:
+            fallback = supplier_identifier or self._clean_identifier(entry.get("quote_id"))
+            supplier_name = f"Supplier {fallback}" if fallback else "Unknown supplier"
+        total_cost = self._to_float(
+            entry.get("total_cost")
+            if not self._is_null(entry.get("total_cost"))
+            else entry.get("total_amount")
+        )
+
+        quote_path = entry.get("quote_file_s3_path") or entry.get("s3_path")
+        if isinstance(quote_path, str):
+            quote_path = quote_path.strip() or None
+        elif self._is_null(quote_path):
+            quote_path = None
+
+        tenure = entry.get("tenure") or entry.get("payment_terms")
+        if isinstance(tenure, (int, float, Decimal)) and not self._is_null(tenure):
+            tenure_value: Optional[float] = self._to_float(tenure)
+        else:
+            tenure_value = tenure if tenure not in ("", None) else None
+
+        return {
+            "name": supplier_name,
+            "supplier_id": supplier_identifier,
+            "total_spend": self._to_float(
+                entry.get("total_spend")
+                if not self._is_null(entry.get("total_spend"))
+                else entry.get("total_amount")
+            ),
+            "total_cost": total_cost,
+            "unit_price": self._to_float(
+                entry.get("unit_price") if not self._is_null(entry.get("unit_price")) else entry.get("avg_unit_price")
+            ),
+            "quote_file_s3_path": quote_path,
+            "tenure": tenure_value,
+            "volume": self._to_float(entry.get("volume") or entry.get("line_items_count")),
+        }
+
+    def _clean_identifier(self, value: Optional[object]) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _to_float(self, value: Optional[object]) -> float:
+        if self._is_null(value):
+            return 0.0
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            try:
+                return float(str(value).replace(",", ""))
+            except (TypeError, ValueError):
+                return 0.0
+
+    @staticmethod
+    def _is_null(value: Optional[object]) -> bool:
+        if value is None:
+            return True
+        try:
+            return bool(pd.isna(value))
+        except Exception:
+            return False
 
     def _collect_supplier_ids(self, input_data: Dict) -> Set[str]:
         supplier_ids: Set[str] = set()
@@ -156,6 +394,18 @@ class QuoteComparisonAgent(BaseAgent):
             "tenure": None,
             "volume": 0.0,
         }
+        if isinstance(weights, (int, float, Decimal)):
+            result = default.copy()
+            result["total_spend"] = float(weights)
+            return result
+        if isinstance(weights, str):
+            try:
+                value = float(weights)
+            except (TypeError, ValueError):
+                return default
+            result = default.copy()
+            result["total_spend"] = value
+            return result
         if not isinstance(weights, dict):
             return default
         result = default.copy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 pydantic-settings
 boto3
 psycopg2-binary
+sqlalchemy
 ollama
 pdfplumber
 pymupdf

--- a/tests/test_quote_comparison_agent.py
+++ b/tests/test_quote_comparison_agent.py
@@ -1,0 +1,148 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pandas as pd
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agents.base_agent import AgentContext, AgentStatus
+from agents.quote_comparison_agent import QuoteComparisonAgent
+
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
+os.environ.setdefault("OLLAMA_USE_GPU", "1")
+os.environ.setdefault("OLLAMA_NUM_PARALLEL", "4")
+os.environ.setdefault("OMP_NUM_THREADS", "8")
+
+
+class DummyNick:
+    def __init__(self):
+        self.settings = SimpleNamespace(script_user="tester")
+        self.process_routing_service = SimpleNamespace(
+            log_process=lambda **_: None,
+            log_action=lambda **_: None,
+        )
+        self.ollama_options = lambda: {}
+        self.pandas_connection = None
+
+    def get_db_connection(self):  # pragma: no cover - defensive
+        raise AssertionError("Database access should not be required in this test")
+
+
+def _build_context(quotes_payload, extra_input=None):
+    base_input = {
+        "quotes": quotes_payload,
+        "weights": 1.0,
+        "supplier_ids": ["S1", "S2"],
+    }
+    if extra_input:
+        base_input.update(extra_input)
+    return AgentContext(
+        workflow_id="wf-1",
+        agent_id="quote_comparison",
+        user_id="tester",
+        input_data=base_input,
+    )
+
+
+def test_quote_comparison_prefers_passed_quotes(monkeypatch):
+    nick = DummyNick()
+    agent = QuoteComparisonAgent(nick)
+
+    def fail_read(*_args, **_kwargs):  # pragma: no cover - should not be invoked
+        raise AssertionError("QuoteComparisonAgent should not read from the database")
+
+    monkeypatch.setattr(agent, "_read_table", fail_read)
+
+    quotes_payload = [
+        {
+            "name": "weighting",
+            "total_spend": 1.0,
+            "total_cost": 0,
+            "unit_price": 0,
+            "quote_file_s3_path": None,
+            "tenure": None,
+            "volume": None,
+        },
+        {
+            "name": "Supplier A",
+            "supplier_id": "S1",
+            "total_spend": 100,
+            "total_cost": 90,
+            "unit_price": 10,
+            "volume": 10,
+            "tenure": "Net 30",
+            "quote_file_s3_path": "s3://bucket/s1.pdf",
+        },
+        {
+            "name": "Supplier B",
+            "supplier_id": "S2",
+            "total_spend": 200,
+            "total_cost": 180,
+            "unit_price": 9,
+            "volume": 20,
+            "tenure": "Net 45",
+            "quote_file_s3_path": "s3://bucket/s2.pdf",
+        },
+    ]
+
+    context = _build_context(quotes_payload)
+    result = agent.run(context)
+
+    assert result.status == AgentStatus.SUCCESS
+    comparison = result.data["comparison"]
+    assert len(comparison) == 3
+    assert comparison[0]["name"] == "weighting"
+    suppliers = {row["supplier_id"] for row in comparison if row["name"] != "weighting"}
+    assert suppliers == {"S1", "S2"}
+    assert comparison[1]["quote_file_s3_path"] == "s3://bucket/s1.pdf"
+
+
+def test_quote_comparison_filters_by_supplier_tokens(monkeypatch):
+    nick = DummyNick()
+    agent = QuoteComparisonAgent(nick)
+
+    # Avoid database fallbacks for the test scenario
+    monkeypatch.setattr(agent, "_read_table", lambda *_args, **_kwargs: pd.DataFrame())
+
+    quotes_payload = [
+        {
+            "name": "weighting",
+            "total_spend": 1.0,
+            "total_cost": 0,
+            "unit_price": 0,
+            "quote_file_s3_path": None,
+            "tenure": None,
+            "volume": None,
+        },
+        {
+            "name": "Supplier A",
+            "supplier_id": "S1",
+            "total_spend": 100,
+            "total_cost": 90,
+            "unit_price": 10,
+            "volume": 10,
+        },
+        {
+            "name": "Supplier B",
+            "supplier_id": None,
+            "total_spend": 200,
+            "total_cost": 180,
+            "unit_price": 9,
+            "volume": 20,
+        },
+    ]
+
+    context = _build_context(
+        quotes_payload,
+        extra_input={"supplier_ids": [], "supplier_names": ["Supplier B"]},
+    )
+
+    result = agent.run(context)
+
+    assert result.status == AgentStatus.SUCCESS
+    comparison = result.data["comparison"]
+    assert len(comparison) == 2
+    assert comparison[0]["name"] == "weighting"
+    assert comparison[1]["name"] == "Supplier B"
+    assert comparison[1]["supplier_id"] is None


### PR DESCRIPTION
## Summary
- consume QuoteEvaluation outputs when available so quote comparison results populate for the requested suppliers before hitting the database fallback
- normalise weighting rows, supplier filters, and S3 paths when aggregating quotes to keep metadata intact during comparisons
- add tests covering pass-through quote behaviour and supplier token filtering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9bab0a44083329debd789eeca106e