### PR TITLE
Add opportunity feedback API and enhance quote analysis

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -1038,6 +1038,12 @@ class Orchestrator:
                 downstream_agents.append(normalised)
                 seen_downstream.add(normalised)
 
+        if should_run_opportunity and "email_drafting" in seen_downstream:
+            downstream_agents = [
+                agent_name for agent_name in downstream_agents if agent_name != "email_drafting"
+            ]
+            seen_downstream.discard("email_drafting")
+
         if downstream_agents:
             downstream_results: Dict[str, Any] = {}
             for agent_name in downstream_agents:

--- a/services/opportunity_service.py
+++ b/services/opportunity_service.py
@@ -1,0 +1,157 @@
+"""Utility helpers for persisting opportunity feedback state."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_feedback_table(conn) -> None:
+    """Ensure the feedback table exists with the expected schema."""
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("CREATE SCHEMA IF NOT EXISTS proc")
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS proc.opportunity_feedback (
+                    opportunity_id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    reason TEXT,
+                    user_id TEXT,
+                    metadata JSONB,
+                    created_on TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_on TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            cur.execute(
+                "ALTER TABLE proc.opportunity_feedback ADD COLUMN IF NOT EXISTS metadata JSONB"
+            )
+            cur.execute(
+                """
+                ALTER TABLE proc.opportunity_feedback
+                ADD COLUMN IF NOT EXISTS updated_on TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                """
+            )
+        conn.commit()
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to ensure opportunity feedback table")
+        conn.rollback()
+
+
+def record_opportunity_feedback(
+    agent_nick,
+    opportunity_id: str,
+    *,
+    status: str,
+    reason: Optional[str] = None,
+    user_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Insert or update feedback for a given opportunity."""
+
+    payload: Dict[str, Any]
+    try:
+        with agent_nick.get_db_connection() as conn:
+            _ensure_feedback_table(conn)
+            serialised_meta = json.dumps(metadata) if metadata is not None else None
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO proc.opportunity_feedback
+                        (opportunity_id, status, reason, user_id, metadata, updated_on)
+                    VALUES (%s, %s, %s, %s, %s::jsonb, NOW())
+                    ON CONFLICT (opportunity_id)
+                    DO UPDATE SET
+                        status = EXCLUDED.status,
+                        reason = EXCLUDED.reason,
+                        user_id = EXCLUDED.user_id,
+                        metadata = EXCLUDED.metadata,
+                        updated_on = NOW()
+                    RETURNING opportunity_id, status, reason, user_id, metadata, updated_on
+                    """,
+                    (
+                        opportunity_id,
+                        status,
+                        reason,
+                        user_id,
+                        serialised_meta,
+                    ),
+                )
+                row = cur.fetchone()
+            conn.commit()
+        if not row:
+            raise RuntimeError("No feedback row returned")
+
+        payload = {
+            "opportunity_id": row[0],
+            "status": row[1],
+            "reason": row[2],
+            "user_id": row[3],
+            "metadata": _deserialize_metadata(row[4]),
+            "updated_on": _coerce_datetime(row[5]),
+        }
+    except Exception:
+        logger.exception("Failed to persist opportunity feedback")
+        raise
+    return payload
+
+
+def load_opportunity_feedback(agent_nick) -> Dict[str, Dict[str, Any]]:
+    """Return a mapping of opportunity ids to recorded feedback."""
+
+    feedback: Dict[str, Dict[str, Any]] = {}
+    try:
+        with agent_nick.get_db_connection() as conn:
+            _ensure_feedback_table(conn)
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT opportunity_id, status, reason, user_id, metadata, updated_on
+                    FROM proc.opportunity_feedback
+                    """
+                )
+                rows = cur.fetchall() or []
+        for row in rows:
+            opportunity_id = row[0]
+            if not opportunity_id:
+                continue
+            feedback[opportunity_id] = {
+                "status": row[1],
+                "reason": row[2],
+                "user_id": row[3],
+                "metadata": _deserialize_metadata(row[4]),
+                "updated_on": _coerce_datetime(row[5]),
+            }
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("Failed to load opportunity feedback")
+    return feedback
+
+
+def _deserialize_metadata(value: Any) -> Optional[Dict[str, Any]]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, dict):
+        return value
+    try:
+        return json.loads(value)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Unable to decode feedback metadata: %s", value)
+        return None
+
+
+def _coerce_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    if value in (None, ""):
+        return None
+    try:
+        return datetime.fromisoformat(str(value))
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Unable to parse feedback timestamp: %s", value)
+        return None

--- a/tests/test_email_drafting_agent.py
+++ b/tests/test_email_drafting_agent.py
@@ -188,7 +188,7 @@ def test_email_drafting_handles_manual_email_request(monkeypatch):
     assert len(drafts) == 1
     draft = drafts[0]
     assert draft["rfq_id"] == "RFQ-MANUAL"
-    assert draft["sent_status"] is False
+    assert draft["sent_status"] is True
     assert draft["action_id"] == "manual-action"
     assert draft["recipients"] == ["user@example.com", "team@example.com"]
     assert stored[0] == draft

--- a/tests/test_quote_comparison_agent.py
+++ b/tests/test_quote_comparison_agent.py
@@ -96,6 +96,13 @@ def test_quote_comparison_prefers_passed_quotes(monkeypatch):
     suppliers = {row["supplier_id"] for row in comparison if row["name"] != "weighting"}
     assert suppliers == {"S1", "S2"}
     assert comparison[1]["quote_file_s3_path"] == "s3://bucket/s1.pdf"
+    assert comparison[1]["currency"] == "GBP"
+    assert comparison[1]["weighting_score"] > comparison[2]["weighting_score"]
+    recommended = result.data.get("recommended_quote")
+    assert recommended is not None
+    assert recommended["supplier_id"] == "S1"
+    assert recommended["ticker"] == "RECOMMENDED"
+    assert recommended["weighting_score"] == comparison[1]["weighting_score"]
 
 
 def test_quote_comparison_filters_by_supplier_tokens(monkeypatch):
@@ -146,3 +153,6 @@ def test_quote_comparison_filters_by_supplier_tokens(monkeypatch):
     assert comparison[0]["name"] == "weighting"
     assert comparison[1]["name"] == "Supplier B"
     assert comparison[1]["supplier_id"] is None
+    recommended = result.data.get("recommended_quote")
+    assert recommended is not None
+    assert recommended["name"] == "Supplier B"


### PR DESCRIPTION
## Summary
- add an opportunity feedback service and expose a `/workflows/opportunities/{opportunity_id}/reject` endpoint that records rejection metadata
- annotate opportunity miner findings with stored feedback so rejected items are flagged in agent output
- enrich quote comparison with currency conversions, weighting scores, and a recommended quote ticker plus justification
- tighten email drafting output by updating the template, removing suggestion language, ensuring manual sends flip the sent flag, and prevent duplicate email agent execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caef55384083328957ef1f14c6e3cc