### PR TITLE
Refine agent registry and email flows

### DIFF
--- a/agents/registry.py
+++ b/agents/registry.py
@@ -1,0 +1,94 @@
+"""Agent registry with alias resolution for ProcWise agents."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+class AgentRegistry(dict):
+    """Dictionary-like registry that supports alias lookups.
+
+    The registry stores agents keyed by their canonical slug (typically the
+    snake_case variant of the agent class name).  Additional aliases can be
+    registered to allow legacy identifiers such as CamelCase class names to
+    resolve to the same instance without duplicating entries in the mapping.
+    """
+
+    def __init__(
+        self,
+        initial: Optional[Dict[str, Any]] = None,
+        *,
+        aliases: Optional[Dict[str, str]] = None,
+    ) -> None:
+        super().__init__(initial or {})
+        self._aliases: Dict[str, str] = {}
+        if aliases:
+            self.add_aliases(aliases)
+
+    # ------------------------------------------------------------------
+    # Alias management helpers
+    # ------------------------------------------------------------------
+    def add_alias(self, alias: Optional[str], target: Optional[str]) -> None:
+        """Register ``alias`` as an alternative key for ``target``."""
+
+        if not alias or not target:
+            return
+        if target not in self:
+            return
+        # Preserve the original alias and a lower-case variant for
+        # case-insensitive lookup.  ``alias`` may already be lower-case so the
+        # two assignments will harmlessly overlap.
+        self._aliases[str(alias)] = target
+        if isinstance(alias, str):
+            self._aliases[alias.lower()] = target
+
+    def add_aliases(self, mapping: Dict[str, str]) -> None:
+        for alias, target in (mapping or {}).items():
+            self.add_alias(alias, target)
+
+    # ------------------------------------------------------------------
+    # Lookup helpers
+    # ------------------------------------------------------------------
+    def _resolve_key(self, key: Any) -> Optional[str]:
+        if key is None:
+            return None
+        if super().__contains__(key):
+            return key
+        if isinstance(key, str):
+            lower = key.lower()
+            if super().__contains__(lower):
+                return lower
+            alias_target = self._aliases.get(key) or self._aliases.get(lower)
+            if alias_target and super().__contains__(alias_target):
+                return alias_target
+        return None
+
+    def __contains__(self, key: object) -> bool:  # type: ignore[override]
+        return self._resolve_key(key) is not None
+
+    def __getitem__(self, key: Any) -> Any:  # type: ignore[override]
+        resolved = self._resolve_key(key)
+        if resolved is None:
+            raise KeyError(key)
+        return super().__getitem__(resolved)
+
+    def get(self, key: Any, default: Any = None) -> Any:  # type: ignore[override]
+        resolved = self._resolve_key(key)
+        if resolved is None:
+            return default
+        return super().get(resolved, default)
+
+    def keys(self):  # type: ignore[override]
+        return super().keys()
+
+    def values(self):  # type: ignore[override]
+        return super().values()
+
+    def items(self):  # type: ignore[override]
+        return super().items()
+
+    def aliases(self) -> Dict[str, str]:
+        """Return a copy of the registered alias mapping."""
+
+        return dict(self._aliases)
+

--- a/api/main.py
+++ b/api/main.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from orchestration.orchestrator import Orchestrator
 from services.model_selector import RAGPipeline
 from agents.base_agent import AgentNick
+from agents.registry import AgentRegistry
 from agents.data_extraction_agent import DataExtractionAgent
 from agents.supplier_ranking_agent import SupplierRankingAgent
 from agents.quote_evaluation_agent import QuoteEvaluationAgent
@@ -41,20 +42,38 @@ async def lifespan(app: FastAPI):
         discrepancy_agent = DiscrepancyDetectionAgent(agent_nick)
         quote_evaluation_agent = QuoteEvaluationAgent(agent_nick)
         quote_comparison_agent = QuoteComparisonAgent(agent_nick)
-        agent_nick.agents = {
-            'data_extraction': DataExtractionAgent(agent_nick),
-            'supplier_ranking': SupplierRankingAgent(agent_nick),
-            'quote_evaluation': quote_evaluation_agent,
-            'opportunity_miner': OpportunityMinerAgent(agent_nick),
-            'DiscrepancyDetectionAgent': discrepancy_agent,
-            'email_drafting': EmailDraftingAgent(agent_nick),
-            'NegotiationAgent': NegotiationAgent(agent_nick),
-            'ApprovalsAgent': ApprovalsAgent(agent_nick),
-            'supplier_interaction': SupplierInteractionAgent(agent_nick),
-            'QuoteEvaluationAgent': quote_evaluation_agent,
-            'quote_comparison': quote_comparison_agent,
-            'QuoteComparisonAgent': quote_comparison_agent,
-        }
+        negotiation_agent = NegotiationAgent(agent_nick)
+        approvals_agent = ApprovalsAgent(agent_nick)
+        supplier_interaction_agent = SupplierInteractionAgent(agent_nick)
+
+        agent_nick.agents = AgentRegistry(
+            {
+                "data_extraction": DataExtractionAgent(agent_nick),
+                "supplier_ranking": SupplierRankingAgent(agent_nick),
+                "quote_evaluation": quote_evaluation_agent,
+                "quote_comparison": quote_comparison_agent,
+                "opportunity_miner": OpportunityMinerAgent(agent_nick),
+                "discrepancy_detection": discrepancy_agent,
+                "email_drafting": EmailDraftingAgent(agent_nick),
+                "negotiation": negotiation_agent,
+                "approvals": approvals_agent,
+                "supplier_interaction": supplier_interaction_agent,
+            }
+        )
+        agent_nick.agents.add_aliases(
+            {
+                "DataExtractionAgent": "data_extraction",
+                "SupplierRankingAgent": "supplier_ranking",
+                "QuoteEvaluationAgent": "quote_evaluation",
+                "QuoteComparisonAgent": "quote_comparison",
+                "OpportunityMinerAgent": "opportunity_miner",
+                "DiscrepancyDetectionAgent": "discrepancy_detection",
+                "EmailDraftingAgent": "email_drafting",
+                "NegotiationAgent": "negotiation",
+                "ApprovalsAgent": "approvals",
+                "SupplierInteractionAgent": "supplier_interaction",
+            }
+        )
         agent_nick.email_watcher = SESEmailWatcher(
             agent_nick,
             supplier_agent=agent_nick.agents.get('supplier_interaction'),

--- a/tests/test_email_drafting_agent.py
+++ b/tests/test_email_drafting_agent.py
@@ -59,8 +59,9 @@ def test_email_drafting_agent(monkeypatch):
     assert draft["supplier_name"] == "Acme"
     assert draft["rfq_id"].startswith("RFQ-")
     assert f"<!-- RFQ-ID: {draft['rfq_id']} -->" in draft["body"]
-    assert "<p>Dear Acme,</p>" in draft["body"]
-    assert "<p>Deadline for submission: 01/01/2025</p>" in draft["body"]
+    assert "<p>Dear Acme, we are reaching out to request your quotation for the requirement below.</p>" in draft["body"]
+    assert "<p>Please submit your response by 01/01/2025.</p>" in draft["body"]
+    assert "<p><strong>Note:</strong> Please do not change the subject line when replying.</p>" in draft["body"]
     assert "<table" in draft["body"]
     assert draft["subject"].count("RFQ") == 1
     assert "leading suppliers" not in draft["body"].lower()


### PR DESCRIPTION
## Summary
- introduce an agent registry with alias resolution to remove duplicate keys in the FastAPI bootstrap
- update the email dispatch service so sending an RFQ flips the stored sent_status in proc.action process_output
- rewrite the default email drafting template to follow the new supplier messaging guidelines and ensure the RFQ table retains a blank row

## Testing
- `pytest tests/test_email_drafting_agent.py tests/test_email_dispatch_service.py tests/test_execute_agent_flow.py tests/test_email_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbcfc91ebc833293952670d85fdd74